### PR TITLE
@stitches/tailwind: update @stitches/css version

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -39,10 +39,10 @@
     "theme"
   ],
   "peerDependencies": {
+    "@stitches/css": "^3.0.0",
     "react": "^16.13.1"
   },
   "dependencies": {
-    "@stitches/css": "^2.3.1",
     "@types/node": "^13.11.1",
     "react-polymorphic-box": "^1.1.0",
     "tslib": "^1.11.1"


### PR DESCRIPTION
Before, tailwind was including its own (incompatible) version of css, which was causing a lot of typing issues in a local environment. I had to add `"resolutions": { "@stitches/css": "3.0.2" },` to my package.json to fix this

Also moves it to use a peer dep, which seems more correct in this case, since it's likely a mistake if `@stitches/css` isn't installed explicitly