### PR TITLE
Fix PolymorphicComponentProps inference

### DIFF
--- a/packages/styled/src/index.tsx
+++ b/packages/styled/src/index.tsx
@@ -16,7 +16,7 @@ type PolymorphicComponentProps<
   E extends React.ElementType,
   P
 > = E extends PolymorphicComponent<infer PP, infer PE>
-  ? P & PP & BoxOwnProps<E> & Omit<PropsOf<PE>, "as">
+  ? P & BoxOwnProps<E> & Omit<PropsOf<PE>, "as">
   : P & BoxProps<E>;
 
 export type PolymorphicComponent<P, D extends React.ElementType = "div"> = (<


### PR DESCRIPTION
I'm not entirely sure if the code I've removed is needed for an edge-case but without this change, prop types were breaking. 

**BEFORE**

![types](https://user-images.githubusercontent.com/175330/87544925-1ef9ab80-c69f-11ea-9321-debaddace855.gif)

**AFTER**

![types](https://user-images.githubusercontent.com/175330/87545017-3df83d80-c69f-11ea-9667-b3fd3f1758dc.gif)