### PR TITLE
Add simple ampersand support and fix nesting normal alphabet selectors

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -347,7 +347,7 @@ export const createCss = <T extends IConfig>(
           );
         }
         createCssAtoms(props[prop], cb, prop, pseudo);
-      } else if (!prop[0].match(/[a-zA-Z]/)) {
+      } else if (typeof props[prop] === 'object') {
         createCssAtoms(props[prop], cb, screen, pseudo.concat(prop));
       } else if (canCallUtils && prop in utils) {
         createCssAtoms(

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -23,6 +23,13 @@ export * from "./css-types";
 
 export const hotReloadingCache = new Map<string, any>();
 
+/**
+ * A reducer function that resolves nesting for a given array of pseudo (nested selectors)
+ */
+const pseudosReducer = (aggr: string, currentPseudo: string) =>
+  aggr +
+  (currentPseudo[0] === "&" ? currentPseudo.substring(1) : ` ${currentPseudo}`);
+
 const toStringCachedAtom = function (this: IAtom) {
   return this._className!;
 };
@@ -365,7 +372,7 @@ export const createCss = <T extends IConfig>(
             prop,
             props[prop],
             screen,
-            pseudo.length ? pseudo.join("") : undefined
+            pseudo.length ? pseudo.reduce(pseudosReducer, "") : undefined
           )
         );
       }


### PR DESCRIPTION
### A couple of small changes:
---------
**Adds simple ampersand support (Fixes #60):**
Before: 
```js
const Button = styled.button({
  ':hover': {},
  ' .nested': {},
})
```

After:
```js
const Button = styled.button({
  '&:hover': {},
  '.nested': {},
})
```

> Note: as agreed on slack and in #60. this is a simple implementation that only deals with the ampersand at the start of a selector and doesn't try to mock the way it works in Sass and other css in js libraries.

---------
**Fixes nesting for rules that start with an alphabetical character (span, div, etc..)**
Before:
```js
const Button = styled.button({
// span styles would be treated as a single css value
  'span': {},

})
```

After:
It will treat it as a nested style object correctly.