### PR TITLE
Feature/css keyframe animations

### DIFF
--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -304,10 +304,10 @@ const createThemeToString = (classPrefix: string, variablesSheet: ISheet) =>
     return themeClassName;
   };
 
-const createKeyframesToString = (variablesSheet: ISheet) =>
+const createKeyframesToString = (sheet: ISheet) =>
   function toString(this: IKeyframesAtom) {
     if (this._cssRuleString) {
-      variablesSheet.insertRule(this._cssRuleString);
+      sheet.insertRule(this._cssRuleString);
     }
 
     this.toString = () => this.id;

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -109,8 +109,7 @@ const resolveStyleObj = (
     }
     // shorthand css props or css props that has baked in handling:
     // see specificityProps in ./utils
-    if (key in specificityProps) {
-      // Merge resolved specificity props:
+    if (isSpecificityProp) {
       const resolvedSpecificityProps = specificityProps[key](config)(val);
       // Call the value middleware on all values:
       callCallbackOnObjectValues(
@@ -471,6 +470,7 @@ export const createCss = <T extends IConfig>(
   };
 
   // pre-checked config to avoid checking these all the time
+  // TODO: handle defaults better
   const screens = (config.screens = config.screens || {});
   const utils = (config.utils = config.utils || {});
   const tokens = (config.tokens = config.tokens || {});
@@ -554,7 +554,6 @@ export const createCss = <T extends IConfig>(
   cssInstance.keyframes = (definition: any): IKeyframesAtom => {
     let cssRule = "";
     let currentTimeProp = "";
-    console.log({ definition });
     resolveStyleObj(definition, config, (key, value, [timeProp]) => {
       if (timeProp !== currentTimeProp) {
         if (cssRule) {
@@ -567,7 +566,7 @@ export const createCss = <T extends IConfig>(
         key,
         vendorProps,
         vendorPrefix
-      )}: ${value};`;
+      )}: ${resolveTokens(key, value, tokens)};`;
     });
 
     const hash = hashString(cssRule);

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -2,7 +2,7 @@ import {
   ATOM,
   IAtom,
   IComposedAtom,
-  IConfig,
+  TConfig,
   ICssPropToToken,
   IScreens,
   ISheet,
@@ -79,7 +79,7 @@ const callCallbackOnObjectValues = <T>(
  */
 const processStyleObject = (
   obj: any,
-  config: IConfig<true>,
+  config: TConfig<true>,
   valueMiddleware: (
     prop: string,
     value: string,
@@ -151,7 +151,7 @@ const processStyleObject = (
  */
 const resolveScreenAndSelector = (
   nestingPath: string[],
-  config: IConfig<true>
+  config: TConfig<true>
 ) =>
   nestingPath.reduce(
     (acc, screenOrSelector, i) => {
@@ -373,12 +373,12 @@ const composeIntoMap = (
 export const createTokens = <T extends ITokensDefinition>(tokens: T) => {
   return tokens;
 };
-export const createCss = <T extends IConfig>(
+export const createCss = <T extends TConfig>(
   _config: T,
   env: Window | null = typeof window === "undefined" ? null : window
 ): TCss<T> => {
   // pre-checked config to avoid checking these all the time
-  const config: IConfig<true> = Object.assign(
+  const config: TConfig<true> = Object.assign(
     { tokens: {}, utils: {}, screens: {} },
     _config
   );

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -347,15 +347,15 @@ export interface ITokensDefinition {
   transitions?: ITokenDefinition;
 }
 
-export interface IConfig {
+export interface IConfig<T extends boolean = false > {
   showFriendlyClassnames?: boolean;
   prefix?: string;
   utilityFirst?: boolean;
-  screens?: IScreens;
-  tokens?: ITokensDefinition;
-  utils?: {
+  screens: IScreens| (T extends true ? never : undefined ) ;
+  tokens:  ITokensDefinition | (T extends true ? never : undefined ) ;
+  utils: {
     [name: string]: TUtility<any, any>;
-  };
+  }| (T extends true ? never : undefined ) ;
 }
 
 export type TUtilityFirstCss<T extends IConfig> = T["screens"] extends unknown

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -37,6 +37,13 @@ export interface IComposedAtom {
   [ATOM]: true;
 }
 
+export interface IKeyframesAtom {
+  id: string;
+  _cssRuleString?: string;
+  toString: (this: IKeyframesAtom) => string;
+  [ATOM]: true;
+}
+
 export type TRecursiveCss<
   T extends IConfig,
   D = {
@@ -55,6 +62,26 @@ export type TRecursiveCss<
     }
 ) &
   D;
+
+export type TFlatCSS<
+  T extends IConfig,
+  D = {
+    [K in keyof Properties]?: K extends keyof ICssPropToToken<T>
+      ? ICssPropToToken<T>[K] | Properties[K]
+      : Properties[K];
+  }
+> = D;
+
+export type TFlatUtils<
+  T extends IConfig,
+  UT = {
+    [U in keyof T["utils"]]?: T["utils"][U] extends TUtility<any, any>
+      ? ReturnType<T["utils"][U]> extends (arg: infer A) => {}
+        ? A
+        : never
+      : never;
+  }
+> = UT;
 
 export type TRecursiveUtils<
   T extends IConfig,
@@ -359,6 +386,7 @@ export interface TCssConstructor<
 > {
   (...styles: (S | string | boolean | null | undefined)[]): string;
   getStyles: (callback: () => any) => { styles: string[]; result: any };
+  keyframes: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => string;
   theme: (
     theme: Partial<
       {

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -347,15 +347,15 @@ export interface ITokensDefinition {
   transitions?: ITokenDefinition;
 }
 
-export interface IConfig<T extends boolean = false > {
+export interface IConfig<STRICT_MODE extends boolean = false > {
   showFriendlyClassnames?: boolean;
   prefix?: string;
   utilityFirst?: boolean;
-  screens: IScreens| (T extends true ? never : undefined ) ;
-  tokens:  ITokensDefinition | (T extends true ? never : undefined ) ;
+  screens: IScreens| (STRICT_MODE extends true ? never : undefined ) ;
+  tokens:  ITokensDefinition | (STRICT_MODE extends true ? never : undefined ) ;
   utils: {
     [name: string]: TUtility<any, any>;
-  }| (T extends true ? never : undefined ) ;
+  }| (STRICT_MODE extends true ? never : undefined ) ;
 }
 
 export type TUtilityFirstCss<T extends IConfig> = T["screens"] extends unknown

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -5,6 +5,7 @@ import {
   LineWidth,
   Properties,
 } from "./css-types";
+import { StrictMode } from "react";
 
 export interface IScreens {
   [key: string]: (css: string) => string;
@@ -45,7 +46,7 @@ export interface IKeyframesAtom {
 }
 
 export type TRecursiveCss<
-  T extends IConfig,
+  T extends TConfig,
   D = {
     [K in keyof Properties]?: K extends keyof ICssPropToToken<T>
       ? ICssPropToToken<T>[K] | Properties[K]
@@ -64,7 +65,7 @@ export type TRecursiveCss<
   D;
 
 export type TFlatCSS<
-  T extends IConfig,
+  T extends TConfig,
   D = {
     [K in keyof Properties]?: K extends keyof ICssPropToToken<T>
       ? ICssPropToToken<T>[K] | Properties[K]
@@ -73,7 +74,7 @@ export type TFlatCSS<
 > = D;
 
 export type TFlatUtils<
-  T extends IConfig,
+  T extends TConfig,
   UT = {
     [U in keyof T["utils"]]?: T["utils"][U] extends TUtility<any, any>
       ? ReturnType<T["utils"][U]> extends (arg: infer A) => {}
@@ -84,7 +85,7 @@ export type TFlatUtils<
 > = UT;
 
 export type TRecursiveUtils<
-  T extends IConfig,
+  T extends TConfig,
   UT = {
     [U in keyof T["utils"]]?: T["utils"][U] extends TUtility<any, any>
       ? ReturnType<T["utils"][U]> extends (arg: infer A) => {}
@@ -104,11 +105,11 @@ export type TRecursiveUtils<
 ) &
   UT;
 
-export type TUtility<A extends any, T extends IConfig> = (
+export type TUtility<A extends any, T extends TConfig> = (
   config: T
 ) => (arg: A) => TRecursiveCss<T>;
 
-export type ICssPropToToken<T extends IConfig> = T["tokens"] extends object
+export type ICssPropToToken<T extends TConfig> = T["tokens"] extends object
   ? {
       border: [
         LineWidth<(string & {}) | 0>,
@@ -346,19 +347,23 @@ export interface ITokensDefinition {
   zIndices?: ITokenDefinition;
   transitions?: ITokenDefinition;
 }
+export interface IUtils {
+  [name: string]: TUtility<any, any>;
+}
 
-export interface IConfig<STRICT_MODE extends boolean = false > {
+export type TConfig<STRICT_MODE extends boolean = false> = {
   showFriendlyClassnames?: boolean;
   prefix?: string;
   utilityFirst?: boolean;
-  screens: IScreens| (STRICT_MODE extends true ? never : undefined ) ;
-  tokens:  ITokensDefinition | (STRICT_MODE extends true ? never : undefined ) ;
-  utils: {
-    [name: string]: TUtility<any, any>;
-  }| (STRICT_MODE extends true ? never : undefined ) ;
-}
+} & (STRICT_MODE extends true
+  ? { screens: IScreens; tokens: ITokensDefinition; utils: IUtils }
+  : {
+      screens?: IScreens;
+      tokens?: ITokensDefinition;
+      utils?: IUtils;
+    });
 
-export type TUtilityFirstCss<T extends IConfig> = T["screens"] extends unknown
+export type TUtilityFirstCss<T extends TConfig> = T["screens"] extends unknown
   ? {
       override?: TRecursiveCss<T>;
     } & TRecursiveUtils<T>
@@ -372,7 +377,7 @@ export type TUtilityFirstCss<T extends IConfig> = T["screens"] extends unknown
     } &
       TRecursiveUtils<T>;
 
-export type TDefaultCss<T extends IConfig> = T["screens"] extends object
+export type TDefaultCss<T extends TConfig> = T["screens"] extends object
   ? TRecursiveCss<T> &
       TRecursiveUtils<T> &
       {
@@ -381,12 +386,14 @@ export type TDefaultCss<T extends IConfig> = T["screens"] extends object
   : TRecursiveCss<T> & TRecursiveUtils<T>;
 
 export interface TCssConstructor<
-  T extends IConfig,
+  T extends TConfig,
   S extends TDefaultCss<T> | TUtilityFirstCss<T>
 > {
   (...styles: (S | string | boolean | null | undefined)[]): string;
   getStyles: (callback: () => any) => { styles: string[]; result: any };
-  keyframes: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => string;
+  keyframes: (
+    definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>
+  ) => string;
   theme: (
     theme: Partial<
       {
@@ -396,7 +403,7 @@ export interface TCssConstructor<
   ) => string;
 }
 
-export type TCss<T extends IConfig> = T extends { utilityFirst: true }
+export type TCss<T extends TConfig> = T extends { utilityFirst: true }
   ? TCssConstructor<T, TUtilityFirstCss<T>>
   : TCssConstructor<T, TDefaultCss<T>>;
 

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -301,5 +301,37 @@ export const hashString = (str: string) => {
   /* JavaScript does bitwise operations (like XOR, above) on 32-bit signed
    * integers. Since we want the results to be always positive, convert the
    * signed int to an unsigned by doing an unsigned bitshift. */
-  return hash >>> 0;
+  return generateAlphabeticName(hash >>> 0);
 };
+
+/**
+ * Converts a hash number to alphabetic representation:
+ * Copied from:
+ * https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/generateAlphabeticName.js
+ */
+
+const AD_REPLACER_R = /(a)(d)/gi;
+
+/* This is the "capacity" of our alphabet i.e. 2x26 for all letters plus their capitalised
+ * counterparts */
+const charsLength = 52;
+
+/* start at 75 for 'a' until 'z' (25) and then start at 65 for capitalised letters */
+const getAlphabeticChar = (code: number): string =>
+  String.fromCharCode(code + (code > 25 ? 39 : 97));
+
+/* input a number, usually a hash and convert it to base-52 */
+function generateAlphabeticName(code: number): string {
+  let name = "";
+  let x;
+
+  /* get a char and divide by alphabet-length */
+  for (x = Math.abs(code); x > charsLength; x = (x / charsLength) | 0) {
+    name = getAlphabeticChar(x % charsLength) + name;
+  }
+
+  return (getAlphabeticChar(x % charsLength) + name).replace(
+    AD_REPLACER_R,
+    "$1-$2"
+  );
+}

--- a/packages/css/tests/index.test.ts
+++ b/packages/css/tests/index.test.ts
@@ -1,4 +1,3 @@
-
 import { createCss, createTokens, hotReloadingCache } from "../src";
 
 function createStyleSheet(styleTag: HTMLStyleElement): CSSStyleSheet {
@@ -537,6 +536,92 @@ describe("createCss", () => {
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
       "/* STITCHES */\n\n._Eogfp{color:var(--colors-primary);}"
+    );
+  });
+
+  test("should generate keyframe atoms", () => {
+    const css = createCss({}, null);
+    const keyFrame = css.keyframes({
+      "0%": { background: "red" },
+      "100%": { background: "green" },
+    }) as any;
+
+    expect(keyFrame._cssRuleString).toBe(
+      "@keyframes kNUAiX {0% {background: red;}100% {background: green;}"
+    );
+
+    expect(keyFrame.toString()).toBe("kNUAiX");
+  });
+
+  test("should support utils inside keyframes", () => {
+    const css = createCss(
+      {
+        utils: {
+          mx: (config) => (value) => ({
+            marginLeft: value,
+            marginRight: value,
+          }),
+        },
+      },
+      null
+    );
+    const keyFrame = css.keyframes({
+      "0%": { mx: "1px" },
+      "100%": { mx: "10px" },
+    }) as any;
+
+    expect(keyFrame._cssRuleString).toBe(
+      "@keyframes bFeLcH {0% {margin-left: 1px;margin-right: 1px;}100% {margin-left: 10px;margin-right: 10px;}"
+    );
+
+    expect(keyFrame.toString()).toBe("bFeLcH");
+  });
+
+  test("should support specificity props inside keyframes", () => {
+    const css = createCss({}, null);
+    const keyFrame = css.keyframes({
+      "0%": { padding: "1px" },
+      "100%": { padding: "10px" },
+    }) as any;
+
+    expect(keyFrame._cssRuleString).toBe(
+      "@keyframes hAOsXf {0% {padding-left: 1px;padding-top: 1px;padding-right: 1px;padding-bottom: 1px;}100% {padding-left: 10px;padding-top: 10px;padding-right: 10px;padding-bottom: 10px;}"
+    );
+
+    expect(keyFrame.toString()).toBe("hAOsXf");
+  });
+  test("should allow keyframes atom to be used as a direct object value", () => {
+    const css = createCss({}, null);
+    const keyFrame = css.keyframes({
+      "0%": { background: "red" },
+      "100%": { background: "green" },
+    }) as any;
+    let atom: any;
+    const { styles } = css.getStyles(() => {
+      expect(() => (atom = css({ animationName: keyFrame }))).not.toThrow();
+      expect(atom.toString()).toBe("_hVCFgX");
+      return "";
+    });
+    expect(styles.length).toBe(2);
+    expect(styles[1].trim()).toBe(
+      "/* STITCHES */\n\n@keyframes kNUAiX {0% {background: red;}100% {background: green;}\n._hVCFgX{animation-name:kNUAiX;}"
+    );
+  });
+
+    test("should inject styles for animations into sheet", () => {
+    const css = createCss({}, null);
+    const keyFrame = css.keyframes({
+      "0%": { background: "red" },
+      "100%": { background: "green" },
+    }) as any;
+    let atom = css({ animationName: keyFrame }) as any;
+    const { styles } = css.getStyles(() => {
+      expect(atom.toString()).toBe("_hVCFgX");
+      return "";
+    });
+    expect(styles.length).toBe(2);
+    expect(styles[1].trim()).toBe(
+      "/* STITCHES */\n\n@keyframes kNUAiX {0% {background: red;}100% {background: green;}\n._hVCFgX{animation-name:kNUAiX;}"
     );
   });
 });

--- a/packages/css/tests/index.test.ts
+++ b/packages/css/tests/index.test.ts
@@ -1,3 +1,4 @@
+
 import { createCss, createTokens, hotReloadingCache } from "../src";
 
 function createStyleSheet(styleTag: HTMLStyleElement): CSSStyleSheet {
@@ -62,23 +63,23 @@ describe("createCss", () => {
 
     expect(atom.id).toBe("color");
     expect(atom.cssHyphenProp).toEqual("color");
-    expect(atom.pseudo).toBe(undefined);
+    expect(atom.pseudo).toBe("");
     expect(atom.screen).toBe("");
     expect(atom.value).toBe("red");
 
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_1725676875");
+      expect(atom.toString()).toBe("_eCaYfN");
 
       return "";
     });
 
     expect(styles.length).toBe(2);
-    expect(styles[1].trim()).toBe("/* STITCHES */\n\n._1725676875{color:red;}");
+    expect(styles[1].trim()).toBe("/* STITCHES */\n\n._eCaYfN{color:red;}");
   });
   test("should compose atoms", () => {
     const css = createCss({}, null);
     expect(css({ color: "red", backgroundColor: "blue" }).toString()).toBe(
-      "_763805413 _1725676875"
+      "_cayivH _eCaYfN"
     );
   });
   test("should create tokens", () => {
@@ -92,18 +93,18 @@ describe("createCss", () => {
 
     expect(atom.id).toBe("color");
     expect(atom.cssHyphenProp).toEqual("color");
-    expect(atom.pseudo).toBe(undefined);
+    expect(atom.pseudo).toBe("");
     expect(atom.screen).toBe("");
     expect(atom.value).toBe("var(--colors-RED)");
 
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_3389639116");
+      expect(atom.toString()).toBe("_iVFaNG");
       return "";
     });
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._3389639116{color:var(--colors-RED);}"
+      "/* STITCHES */\n\n._iVFaNG{color:var(--colors-RED);}"
     );
   });
   test("should create screens", () => {
@@ -118,34 +119,34 @@ describe("createCss", () => {
     const atom = (css({ tablet: { color: "red" } }) as any).atoms[0];
     expect(atom.id).toBe("colortablet");
     expect(atom.cssHyphenProp).toEqual("color");
-    expect(atom.pseudo).toBe(undefined);
+    expect(atom.pseudo).toBe("");
     expect(atom.screen).toBe("tablet");
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_2796359201");
+      expect(atom.toString()).toBe("_hsxGAz");
       return "";
     });
 
     expect(styles.length).toBe(3);
     expect(styles[2].trim()).toBe(
-      "/* STITCHES:tablet */\n\n@media (min-width: 700px) { ._2796359201{color:red;} }"
+      "/* STITCHES:tablet */\n\n@media (min-width: 700px) { ._hsxGAz{color:red;} }"
     );
   });
   test("should handle pseudos", () => {
     const css = createCss({}, null);
-    const atom = (css({ ":hover": { color: "red" } }) as any).atoms[0];
+    const atom = (css({ "&:hover": { color: "red" } }) as any).atoms[0];
 
     expect(atom.id).toBe("color:hover");
     expect(atom.cssHyphenProp).toEqual("color");
     expect(atom.pseudo).toBe(":hover");
     expect(atom.screen).toBe("");
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_627048087");
+      expect(atom.toString()).toBe("_bHNCzd");
       return "";
     });
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._627048087:hover{color:red;}"
+      "/* STITCHES */\n\n._bHNCzd:hover{color:red;}"
     );
   });
   test("should handle specificity", () => {
@@ -160,27 +161,27 @@ describe("createCss", () => {
           backgroundColor: "green",
         }
       ).toString()
-    ).toBe("_736532192 _1725676875");
+    ).toBe("_bWMkiG _eCaYfN");
   });
   test("should insert rule only once", () => {
     const css = createCss({}, null);
     const { styles } = css.getStyles(() => {
-      expect(css({ color: "red" }).toString()).toBe("_1725676875");
-      expect(css({ color: "red" }).toString()).toBe("_1725676875");
+      expect(css({ color: "red" }).toString()).toBe("_eCaYfN");
+      expect(css({ color: "red" }).toString()).toBe("_eCaYfN");
       return "";
     });
 
     expect(styles.length).toBe(2);
-    expect(styles[1].trim()).toBe("/* STITCHES */\n\n._1725676875{color:red;}");
+    expect(styles[1].trim()).toBe("/* STITCHES */\n\n._eCaYfN{color:red;}");
   });
   test("should handle specificity with different but same pseudo", () => {
     const css = createCss({}, null);
     expect(
       css(
-        { ":hover:disabled": { color: "red" } },
-        { ":disabled:hover": { color: "red" } }
+        { "&:hover:disabled": { color: "red" } },
+        { "&:disabled:hover": { color: "red" } }
       ).toString()
-    ).toBe("_3266759165");
+    ).toBe("_iEPeZH");
   });
   test("should use simple sequence for classname when browser", () => {
     const fakeEnv = createFakeEnv();
@@ -227,7 +228,7 @@ describe("createCss", () => {
       },
       null
     );
-    expect(css({ marginX: "1rem" }).toString()).toBe("_4081121629 _97196166");
+    expect(css({ marginX: "1rem" }).toString()).toBe("_kMiQCn _npnrc");
   });
   test("should ignore undefined atoms", () => {
     const css = createCss({}, null);
@@ -235,7 +236,7 @@ describe("createCss", () => {
     expect(
       // @ts-ignore
       String(css(undefined, null, false, "", { color: "red" }))
-    ).toBe("_1725676875");
+    ).toBe("_eCaYfN");
   });
   test("should allow empty compose call", () => {
     const css = createCss({}, null);
@@ -244,7 +245,7 @@ describe("createCss", () => {
   test("should allow conditional compositions", () => {
     const css = createCss({}, null);
     expect(String(css((false as any) && { color: "red" }))).toBe("");
-    expect(String(css(true && { color: "red" }))).toBe("_1725676875");
+    expect(String(css(true && { color: "red" }))).toBe("_eCaYfN");
   });
   test("should allow prefixes", () => {
     const css = createCss(
@@ -253,7 +254,7 @@ describe("createCss", () => {
       },
       null
     );
-    expect(String(css({ color: "red" }))).toBe("foo_1725676875");
+    expect(String(css({ color: "red" }))).toBe("foo_eCaYfN");
   });
   test("should expose override with utility first", () => {
     const css = createCss(
@@ -265,7 +266,7 @@ describe("createCss", () => {
       },
       null
     );
-    expect(String(css({ override: { color: "red" } }))).toBe("_1725676875");
+    expect(String(css({ override: { color: "red" } }))).toBe("_eCaYfN");
   });
   test("should not inject existing styles", () => {
     const serverCss = createCss({}, null);
@@ -281,7 +282,7 @@ describe("createCss", () => {
     expect(fakeEnv.document.styleSheets.length).toBe(2);
     expect(fakeEnv.document.styleSheets[1].cssRules.length).toBe(1);
     expect(fakeEnv.document.styleSheets[1].cssRules[0].cssText).toBe(
-      "._1725676875 {color: red;}"
+      "._eCaYfN {color: red;}"
     );
     // On the client it will rerun the logic (React hydrate etc.)
     clientCss({ color: "red" }).toString();
@@ -290,7 +291,7 @@ describe("createCss", () => {
     // Lets see if it continues on the correct sequence
     expect(fakeEnv.document.styleSheets[1].cssRules.length).toBe(2);
     expect(fakeEnv.document.styleSheets[1].cssRules[0].cssText).toBe(
-      "._1757807590 {color: blue;}"
+      "._eGvyOg {color: blue;}"
     );
   });
   test("should be able to show friendly classnames", () => {
@@ -308,7 +309,7 @@ describe("createCss", () => {
 
     expect(styles).toEqual([
       `/* STITCHES:__variables__ */\n\n:root{}`,
-      `/* STITCHES */\n\n.c_1725676875{color:red;}\n.bc_1056962344{background-color:red;}`,
+      `/* STITCHES */\n\n.c_eCaYfN{color:red;}\n.bc_cODewW{background-color:red;}`,
     ]);
   });
   test("should inject vendor prefix where explicitly stating so", () => {
@@ -326,13 +327,13 @@ describe("createCss", () => {
 
     expect(styles).toEqual([
       `/* STITCHES:__variables__ */\n\n:root{}`,
-      `/* STITCHES */\n\n.c_1725676875{-webkit-color:red;}`,
+      `/* STITCHES */\n\n.c_eCaYfN{-webkit-color:red;}`,
     ]);
   });
   test("should use specificity props", () => {
     const css = createCss({}, null);
     expect(String(css({ margin: "1px" }))).toBe(
-      "_2683736640 _968032303 _4032728388 _4031826548"
+      "_hdcIia _cCuGfR _kFCHHa _kFwmfW"
     );
   });
   test("should have declarative api", () => {
@@ -342,13 +343,13 @@ describe("createCss", () => {
         color: "red",
         backgroundColor: "blue",
       }).toString()
-    ).toBe("_763805413 _1725676875");
+    ).toBe("_cayivH _eCaYfN");
   });
   test("should handle declarative pseudo selector", () => {
     const fakeEnv = createFakeEnv([], []);
     const css = createCss({}, (fakeEnv as unknown) as Window);
     // @ts-ignore
-    css({ ":hover": { color: "red" } }).toString();
+    css({ "&:hover": { color: "red" } }).toString();
     expect(fakeEnv.document.styleSheets[1].cssRules[0].cssText).toBe(
       "._0:hover {color: red;}"
     );
@@ -370,7 +371,7 @@ describe("createCss", () => {
 
     expect(styles.length).toBe(3);
     expect(styles[2].trim()).toBe(
-      "/* STITCHES:mobile */\n\n@media(min-width:700px){._2196820011{color:red;}}"
+      "/* STITCHES:mobile */\n\n@media(min-width:700px){._fOxLwJ{color:red;}}"
     );
   });
   test("should handle pseudo in screen selector", () => {
@@ -384,13 +385,13 @@ describe("createCss", () => {
     );
     const { styles } = css.getStyles(() => {
       // @ts-ignore
-      css({ mobile: { ":hover": { color: "red" } } }).toString();
+      css({ mobile: { "&:hover": { color: "red" } } }).toString();
       return "";
     });
 
     expect(styles.length).toBe(3);
     expect(styles[2].trim()).toBe(
-      "/* STITCHES:mobile */\n\n@media(min-width:700px){._860048247:hover{color:red;}}"
+      "/* STITCHES:mobile */\n\n@media(min-width:700px){._cnGHjt:hover{color:red;}}"
     );
   });
   test("should insert themes", () => {
@@ -422,22 +423,22 @@ describe("createCss", () => {
     expect(styles.length).toBe(2);
     expect(styles).toEqual([
       "/* STITCHES:__variables__ */\n\n:root{--colors-primary:tomato;}\n.theme-0{--colors-primary:blue;}",
-      "/* STITCHES */\n\n._221333491{color:var(--colors-primary);}",
+      "/* STITCHES */\n\n._Eogfp{color:var(--colors-primary);}",
     ]);
   });
   test("should allow nested pseudo", () => {
     const css = createCss({}, null);
-    const atom = css({ ":hover": { ":disabled": { color: "red" } } }) as any;
+    const atom = css({ "&:hover": { "&:disabled": { color: "red" } } }) as any;
 
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_3266759165");
+      expect(atom.toString()).toBe("_iEPeZH");
 
       return "";
     });
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._3266759165:hover:disabled{color:red;}"
+      "/* STITCHES */\n\n._iEPeZH:hover:disabled{color:red;}"
     );
   });
   test("should handle border specificity", () => {
@@ -446,7 +447,7 @@ describe("createCss", () => {
 
     const { styles } = css.getStyles(() => {
       expect(atom.toString()).toBe(
-        "_3699842268 _4258539560 _3162928263 _2026632940 _1405295864 _397589452 _3971615587 _1515315272 _1917871437 _115517177 _3001088182 _1146082397"
+        "_jMbiSS _lkwFJC _iqEHZB _frjswu _dKkway _bctHBa _kxkaMR _dZmTIq _fcpRZb _pPCSj _hUxHUo _daMVcf"
       );
 
       return "";
@@ -454,7 +455,7 @@ describe("createCss", () => {
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._3699842268{border-left-color:red;}\n._4258539560{border-bottom-color:red;}\n._3162928263{border-right-color:red;}\n._2026632940{border-top-color:red;}\n._1405295864{border-left-style:solid;}\n._397589452{border-bottom-style:solid;}\n._3971615587{border-right-style:solid;}\n._1515315272{border-top-style:solid;}\n._1917871437{border-left-width:1px;}\n._115517177{border-bottom-width:1px;}\n._3001088182{border-right-width:1px;}\n._1146082397{border-top-width:1px;}"
+      "/* STITCHES */\n\n._jMbiSS{border-left-color:red;}\n._lkwFJC{border-bottom-color:red;}\n._iqEHZB{border-right-color:red;}\n._frjswu{border-top-color:red;}\n._dKkway{border-left-style:solid;}\n._bctHBa{border-bottom-style:solid;}\n._kxkaMR{border-right-style:solid;}\n._dZmTIq{border-top-style:solid;}\n._fcpRZb{border-left-width:1px;}\n._pPCSj{border-bottom-width:1px;}\n._hUxHUo{border-right-width:1px;}\n._daMVcf{border-top-width:1px;}"
     );
   });
   test("should handle border array definition with token", () => {
@@ -472,7 +473,7 @@ describe("createCss", () => {
 
     const { styles } = css.getStyles(() => {
       expect(atom.toString()).toBe(
-        "_37328740 _3671545168 _150089599 _4079361620 _1405295864 _397589452 _3971615587 _1515315272 _1917871437 _115517177 _3001088182 _1146082397"
+        "_ffzau _jIhVXS _uBwAx _kLWpHW _dKkway _bctHBa _kxkaMR _dZmTIq _fcpRZb _pPCSj _hUxHUo _daMVcf"
       );
 
       return "";
@@ -480,7 +481,7 @@ describe("createCss", () => {
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._37328740{border-left-color:var(--colors-primary);}\n._3671545168{border-bottom-color:var(--colors-primary);}\n._150089599{border-right-color:var(--colors-primary);}\n._4079361620{border-top-color:var(--colors-primary);}\n._1405295864{border-left-style:solid;}\n._397589452{border-bottom-style:solid;}\n._3971615587{border-right-style:solid;}\n._1515315272{border-top-style:solid;}\n._1917871437{border-left-width:1px;}\n._115517177{border-bottom-width:1px;}\n._3001088182{border-right-width:1px;}\n._1146082397{border-top-width:1px;}"
+      "/* STITCHES */\n\n._ffzau{border-left-color:var(--colors-primary);}\n._jIhVXS{border-bottom-color:var(--colors-primary);}\n._uBwAx{border-right-color:var(--colors-primary);}\n._kLWpHW{border-top-color:var(--colors-primary);}\n._dKkway{border-left-style:solid;}\n._bctHBa{border-bottom-style:solid;}\n._kxkaMR{border-right-style:solid;}\n._dZmTIq{border-top-style:solid;}\n._fcpRZb{border-left-width:1px;}\n._pPCSj{border-bottom-width:1px;}\n._hUxHUo{border-right-width:1px;}\n._daMVcf{border-top-width:1px;}"
     );
   });
   test("should handle box shadow array with token", () => {
@@ -497,14 +498,14 @@ describe("createCss", () => {
     const atom = css({ boxShadow: ["1px", "1px", "1px", "primary"] }) as any;
 
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_3532244265");
+      expect(atom.toString()).toBe("_jpflsr");
 
       return "";
     });
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._3532244265{box-shadow:1px 1px 1px var(--colors-primary);}"
+      "/* STITCHES */\n\n._jpflsr{box-shadow:1px 1px 1px var(--colors-primary);}"
     );
   });
   test("should be able to compose themes", () => {
@@ -528,14 +529,14 @@ describe("createCss", () => {
     }) as any;
 
     const { styles } = css.getStyles(() => {
-      expect(atom.toString()).toBe("_221333491 theme-0");
+      expect(atom.toString()).toBe("_Eogfp theme-0");
 
       return "";
     });
 
     expect(styles.length).toBe(2);
     expect(styles[1].trim()).toBe(
-      "/* STITCHES */\n\n._221333491{color:var(--colors-primary);}"
+      "/* STITCHES */\n\n._Eogfp{color:var(--colors-primary);}"
     );
   });
 });


### PR DESCRIPTION
**Main key points:**
- Keyframes support resolves #68  :
Abstracted the utils/specificity props/screens/ selectors resolving mechanism into functions so that the internal implementation could be shared with `keyframes` and soon in `createGlobalStyles`.
`createCssAtoms` & `createUtilsAtoms` got replaced with the above implementation the same as `keyframes`
- Altered hashing function to produce smaller size classes (needed to hash animations into an animation-name) (fixes: #76) 
- Adds simple ampersand support (Fixes #60)
- Updated tests to work with the new ampersand syntax. @peduarte turns out that christianalfoni already had some tests in place for the CSS package which helped me a lot with discovering bugs I introduced with the abstraction above so might be a good place to start if you want to add to the existing tests in there until we setup testing properly in #75. see `css/tests`
- Longhand parsing will be added in a separate PR after I do a separate package for the whole parsing shenanigans sometime next week
