### PR TITLE
require tokens to be used when defined

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -49,7 +49,7 @@ export type TRecursiveCss<
   T extends TConfig,
   D = {
     [K in keyof Properties]?: K extends keyof ICssPropToToken<T>
-      ? ICssPropToToken<T>[K] | Properties[K]
+      ? ICssPropToToken<T>[K]
       : Properties[K];
   }
 > = (
@@ -68,7 +68,7 @@ export type TFlatCSS<
   T extends TConfig,
   D = {
     [K in keyof Properties]?: K extends keyof ICssPropToToken<T>
-      ? ICssPropToToken<T>[K] | Properties[K]
+      ? ICssPropToToken<T>[K]
       : Properties[K];
   }
 > = D;

--- a/packages/css/tests/index.test.ts
+++ b/packages/css/tests/index.test.ts
@@ -608,7 +608,7 @@ describe("createCss", () => {
     );
   });
 
-    test("should inject styles for animations into sheet", () => {
+  test("should inject styles for animations into sheet", () => {
     const css = createCss({}, null);
     const keyFrame = css.keyframes({
       "0%": { background: "red" },
@@ -623,5 +623,20 @@ describe("createCss", () => {
     expect(styles[1].trim()).toBe(
       "/* STITCHES */\n\n@keyframes kNUAiX {0% {background: red;}100% {background: green;}\n._hVCFgX{animation-name:kNUAiX;}"
     );
+  });
+
+  test("should yield type errors when tokens are defined", () => {
+    const css = createCss({
+      tokens: {
+        colors: {
+          primary: "red",
+        },
+      },
+    });
+    css({
+      color: "primary",
+      // @ts-expect-error
+      backgroundColor: "red",
+    });
   });
 });


### PR DESCRIPTION
With this change the compiler will yield an error when tokens are defined but raw values are used instead.

![carbon](https://user-images.githubusercontent.com/89450/90647147-4d3b4f80-e238-11ea-98d9-ee7717be794b.png)

In order to use non-token values developers must add `as any` or `@ts-ignore`.
 
See https://twitter.com/fgnass/status/1296034855562743808 for the discussion with @christianalfoni 