### PR TITLE
feat: added support for text decoration shorthand and other long hand properties

### DIFF
--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -299,13 +299,13 @@ export const textDecoration = createPropertyParser((tokens: any, css: any, value
 });
 
 export const textDecorationStyle = createPropertyParser((tokens: any, css: any, value: any) => {
-  if (value.match(/solid|double|dotted|dashed|wavy/)) {
+  if (value.match(/solid|double|dotted|dashed|wavy|unset/)) {
     css.textDecorationStyle = value;
   }
 });
 
 export const textDecorationLine = createPropertyParser((tokens: any, css: any, value: any) => {
-  if (value.match(/none|underline|overline|line-through|blink/)) {
+  if (value.match(/none|underline|overline|line-through|blink|unset/)) {
     css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');
   }
 });

--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -296,43 +296,17 @@ export const boxShadow = (tokens: any, value: string) => {
 
 export const textDecoration = createPropertyParser((tokens: any, css: any, value: any) => {
   if (matchString(value, /unset/)) {
-    // we are checking the existing value here because we want to retain the long hand property that was previously applied
-    /**
-     * For example:
-     * textDecorationColor: red
-     * textDecoration: unset
-     *
-     * The above should result in a final css rule like the following
-     * text-decoration-style: unset;
-     * text-decoration-line: unset;
-     * text-decoration-color: red
-     *
-     * This is as per the css rules
-     */
-    css.textDecorationStyle = css.textDecorationStyle || value;
-    css.textDecorationLine = css.textDecorationLine || value;
-    css.textDecorationColor = css.textDecorationColor || value;
+    css.textDecorationStyle = value;
+    css.textDecorationLine = value;
+    css.textDecorationColor = value;
+    css.textDecorationThickness = value;
   } else if (matchString(value, /solid|double|dotted|dashed|wavy/)) {
     css.textDecorationStyle = value;
-  } else if (value.match(/none|underline|overline|line-through|blink/)) {
+  } else if (matchString(value, /none|underline|overline|line-through|blink/)) {
     css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');
+  } else if (matchString(value, unitMatch) || matchString(value, /auto|from-font/)) {
+    css.textDecorationThickness = value;
   } else {
     css.textDecorationColor = tokens.colors[value] || value;
   }
-});
-
-export const textDecorationStyle = createPropertyParser((tokens: any, css: any, value: any) => {
-  if (matchString(value, /solid|double|dotted|dashed|wavy|unset/)) {
-    css.textDecorationStyle = value;
-  }
-});
-
-export const textDecorationLine = createPropertyParser((tokens: any, css: any, value: any) => {
-  if (matchString(value, /none|underline|overline|line-through|blink|unset/)) {
-    css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');
-  }
-});
-
-export const textDecorationColor = createPropertyParser((tokens: any, css: any, value: any) => {
-  css.textDecorationColor = tokens.colors[value] || value;
 });

--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -296,9 +296,22 @@ export const boxShadow = (tokens: any, value: string) => {
 
 export const textDecoration = createPropertyParser((tokens: any, css: any, value: any) => {
   if (matchString(value, /unset/)) {
-    css.textDecorationStyle = value;
-    css.textDecorationLine = value;
-    css.textDecorationColor = value;
+    // we are checking the existing value here because we want to retain the long hand property that was previously applied
+    /**
+     * For example:
+     * textDecorationColor: red
+     * textDecoration: unset
+     *
+     * The above should result in a final css rule like the following
+     * text-decoration-style: unset;
+     * text-decoration-line: unset;
+     * text-decoration-color: red
+     *
+     * This is as per the css rules
+     */
+    css.textDecorationStyle = css.textDecorationStyle || value;
+    css.textDecorationLine = css.textDecorationLine || value;
+    css.textDecorationColor = css.textDecorationColor || value;
   } else if (matchString(value, /solid|double|dotted|dashed|wavy/)) {
     css.textDecorationStyle = value;
   } else if (value.match(/none|underline|overline|line-through|blink/)) {

--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -4,7 +4,8 @@ import { tokenizeValue } from './value-tokenizer';
 const unitMatch = /^[0-9.]+[a-z|%]/;
 const easingMatch = /\(.*\)|ease|ease-in|ease-out|ease-in-out|linear|step-start|step-end/;
 
-const setChainedValue = (existingValue: string, value: string) => (existingValue ? `${existingValue},${value}` : value);
+const setChainedValue = (existingValue: string, value: string, separator = ',') =>
+  existingValue ? `${existingValue}${separator}${value}` : value;
 
 const emptyTokens: any = {};
 tokenTypes.forEach((type) => (emptyTokens[type] = {}));
@@ -286,3 +287,29 @@ export const boxShadow = (tokens: any, value: string) => {
       .join(', '),
   };
 };
+
+export const textDecoration = createPropertyParser((tokens: any, css: any, value: any) => {
+  if (value.match(/solid|double|dotted|dashed|wavy/)) {
+    css.textDecorationStyle = value;
+  } else if (value.match(/none|underline|overline|line-through|blink/)) {
+    css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');
+  } else {
+    css.textDecorationColor = tokens.colors[value] || value;
+  }
+});
+
+export const textDecorationStyle = createPropertyParser((tokens: any, css: any, value: any) => {
+  if (value.match(/solid|double|dotted|dashed|wavy/)) {
+    css.textDecorationStyle = value;
+  }
+});
+
+export const textDecorationLine = createPropertyParser((tokens: any, css: any, value: any) => {
+  if (value.match(/none|underline|overline|line-through|blink/)) {
+    css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');
+  }
+});
+
+export const textDecorationColor = createPropertyParser((tokens: any, css: any, value: any) => {
+  css.textDecorationColor = tokens.colors[value] || value;
+});

--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -295,7 +295,11 @@ export const boxShadow = (tokens: any, value: string) => {
 };
 
 export const textDecoration = createPropertyParser((tokens: any, css: any, value: any) => {
-  if (matchString(value, /solid|double|dotted|dashed|wavy/)) {
+  if (matchString(value, /unset/)) {
+    css.textDecorationStyle = value;
+    css.textDecorationLine = value;
+    css.textDecorationColor = value;
+  } else if (matchString(value, /solid|double|dotted|dashed|wavy/)) {
     css.textDecorationStyle = value;
   } else if (value.match(/none|underline|overline|line-through|blink/)) {
     css.textDecorationLine = setChainedValue(css.textDecorationLine, value, ' ');

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -15,6 +15,7 @@ import {
   margin,
   padding,
   transition,
+  textDecoration,
 } from './shorthand-parser';
 import { IBreakpoints, ICssPropToToken, ISheet } from './types';
 
@@ -238,6 +239,7 @@ export const specificityProps: {
   borderLeft,
   borderTop,
   borderRight,
+  textDecoration,
 };
 
 export const getVendorPrefixAndProps = (env: any) => {

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1287,6 +1287,34 @@ describe('createCss', () => {
     `);
   });
 
+  test('should handle text-decoration shorthand', () => {
+    const css = createCss(
+      {
+        tokens: {
+          colors: {
+            primary: '#222',
+          },
+        },
+      },
+      null
+    );
+    const atom = css({ textDecoration: 'underline overline primary 2px' }) as any;
+
+    const { styles } = css.getStyles(() => {
+      expect(atom.toString()).toMatchInlineSnapshot(`"_AphwG _fkaZbo _cyLCEu"`);
+
+      return '';
+    });
+
+    expect(styles.length).toBe(2);
+    expect(styles[1].trim()).toMatchInlineSnapshot(`
+      "/* STITCHES */
+      ./*X*/_cyLCEu/*X*/{text-decoration-line:underline overline;}
+      ./*X*/_fkaZbo/*X*/{text-decoration-color:var(--colors-primary);}
+      ./*X*/_AphwG/*X*/{text-decoration-thickness:2px;}"
+    `);
+  });
+
   test('should handle font shorthand', () => {
     const css = createCss({}, null);
     const atom = css({ font: '1.2em "Fira Sans", sans-serif' }) as any;

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -964,6 +964,13 @@ describe('Text decoration shorthand', () => {
         "textDecorationStyle": "dotted",
       }
     `);
+    expect(textDecoration(tokens, 'unset')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "unset",
+        "textDecorationLine": "unset",
+        "textDecorationStyle": "unset",
+      }
+    `);
   });
   test('Handles text-decoration-line', () => {
     expect(textDecorationLine(tokens, 'underline overline')).toMatchInlineSnapshot(`

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -15,9 +15,6 @@ import {
   padding,
   transition,
   textDecoration,
-  textDecorationLine,
-  textDecorationStyle,
-  textDecorationColor,
 } from '../src/shorthand-parser';
 
 const tokens = {
@@ -969,92 +966,41 @@ describe('Text decoration shorthand', () => {
         "textDecorationColor": "unset",
         "textDecorationLine": "unset",
         "textDecorationStyle": "unset",
+        "textDecorationThickness": "unset",
       }
     `);
-  });
-  test('Handles text-decoration-line', () => {
-    expect(textDecorationLine(tokens, 'underline overline')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "underline overline",
-      }
-    `);
-    expect(textDecorationLine(tokens, 'none none')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "none none",
-      }
-    `);
-    expect(textDecorationLine(tokens, 'underline')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "underline",
-      }
-    `);
-    expect(textDecorationLine(tokens, 'blink')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "blink",
-      }
-    `);
-    expect(textDecorationLine(tokens, 'line-through none')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "line-through none",
-      }
-    `);
-    expect(textDecorationLine(tokens, 'unset')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationLine": "unset",
-      }
-    `);
-  });
-  test('Handles text-decoration-style', () => {
-    expect(textDecorationStyle(tokens, 'wavy')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "wavy",
-      }
-    `);
-    expect(textDecorationStyle(tokens, 'dashed')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "dashed",
-      }
-    `);
-    expect(textDecorationStyle(tokens, 'dotted')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "dotted",
-      }
-    `);
-    expect(textDecorationStyle(tokens, 'solid')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "solid",
-      }
-    `);
-    expect(textDecorationStyle(tokens, 'double')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "double",
-      }
-    `);
-    expect(textDecorationStyle(tokens, 'unset')).toMatchInlineSnapshot(`
-      Object {
-        "textDecorationStyle": "unset",
-      }
-    `);
-  });
-  test('Handles text-decoration-color', () => {
-    expect(textDecorationColor(tokens, 'red')).toMatchInlineSnapshot(`
+    expect(textDecoration(tokens, 'underline dotted red 50%')).toMatchInlineSnapshot(`
       Object {
         "textDecorationColor": "red",
+        "textDecorationLine": "underline",
+        "textDecorationStyle": "dotted",
+        "textDecorationThickness": "50%",
       }
     `);
-    expect(textDecorationColor(tokens, 'blue')).toMatchInlineSnapshot(`
+    expect(textDecoration(tokens, 'dotted red 4px')).toMatchInlineSnapshot(`
       Object {
-        "textDecorationColor": "blue",
+        "textDecorationColor": "red",
+        "textDecorationStyle": "dotted",
+        "textDecorationThickness": "4px",
       }
     `);
-    expect(textDecorationColor(tokens, 'gray400')).toMatchInlineSnapshot(`
+    expect(textDecoration(tokens, 'dotted red auto')).toMatchInlineSnapshot(`
       Object {
-        "textDecorationColor": "#e3e3e3",
+        "textDecorationColor": "red",
+        "textDecorationStyle": "dotted",
+        "textDecorationThickness": "auto",
       }
     `);
-    expect(textDecorationColor(tokens, 'unset')).toMatchInlineSnapshot(`
+    expect(textDecoration(tokens, 'red 4rem')).toMatchInlineSnapshot(`
       Object {
-        "textDecorationColor": "unset",
+        "textDecorationColor": "red",
+        "textDecorationThickness": "4rem",
+      }
+    `);
+    expect(textDecoration(tokens, 'red from-font')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "red",
+        "textDecorationThickness": "from-font",
       }
     `);
   });

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -1052,5 +1052,10 @@ describe('Text decoration shorthand', () => {
         "textDecorationColor": "#e3e3e3",
       }
     `);
+    expect(textDecorationColor(tokens, 'unset')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "unset",
+      }
+    `);
   });
 });

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -966,6 +966,11 @@ describe('Text decoration shorthand', () => {
         "textDecorationLine": "line-through none",
       }
     `);
+    expect(textDecorationLine(tokens, 'unset')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "unset",
+      }
+    `);
   });
   test('Handles text-decoration-style', () => {
     expect(textDecorationStyle(tokens, 'wavy')).toMatchInlineSnapshot(`
@@ -991,6 +996,11 @@ describe('Text decoration shorthand', () => {
     expect(textDecorationStyle(tokens, 'double')).toMatchInlineSnapshot(`
       Object {
         "textDecorationStyle": "double",
+      }
+    `);
+    expect(textDecorationStyle(tokens, 'unset')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "unset",
       }
     `);
   });

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -10,6 +10,10 @@ import {
   margin,
   padding,
   transition,
+  textDecoration,
+  textDecorationLine,
+  textDecorationStyle,
+  textDecorationColor,
 } from '../src/shorthand-parser';
 
 const tokens = {
@@ -891,6 +895,119 @@ describe('Box-shadow', () => {
     expect(boxShadow(tokens, '60px -16px gray400, 60px -16px gray400')).toMatchInlineSnapshot(`
       Object {
         "boxShadow": "60px -16px #e3e3e3, 60px -16px #e3e3e3",
+      }
+    `);
+  });
+});
+
+describe('Text decoration shorthand', () => {
+  test('Handles text-decoration shorthand', () => {
+    expect(textDecoration(tokens, 'none')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "none",
+      }
+    `);
+    expect(textDecoration(tokens, 'none none')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "none none",
+      }
+    `);
+    expect(textDecoration(tokens, 'red wavy')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "red",
+        "textDecorationStyle": "wavy",
+      }
+    `);
+    expect(textDecoration(tokens, 'underline overline red wavy')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "red",
+        "textDecorationLine": "underline overline",
+        "textDecorationStyle": "wavy",
+      }
+    `);
+    expect(textDecoration(tokens, 'gray400 overline wavy')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "#e3e3e3",
+        "textDecorationLine": "overline",
+        "textDecorationStyle": "wavy",
+      }
+    `);
+    expect(textDecoration(tokens, 'underline dotted red')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "red",
+        "textDecorationLine": "underline",
+        "textDecorationStyle": "dotted",
+      }
+    `);
+  });
+  test('Handles text-decoration-line', () => {
+    expect(textDecorationLine(tokens, 'underline overline')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "underline overline",
+      }
+    `);
+    expect(textDecorationLine(tokens, 'none none')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "none none",
+      }
+    `);
+    expect(textDecorationLine(tokens, 'underline')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "underline",
+      }
+    `);
+    expect(textDecorationLine(tokens, 'blink')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "blink",
+      }
+    `);
+    expect(textDecorationLine(tokens, 'line-through none')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationLine": "line-through none",
+      }
+    `);
+  });
+  test('Handles text-decoration-style', () => {
+    expect(textDecorationStyle(tokens, 'wavy')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "wavy",
+      }
+    `);
+    expect(textDecorationStyle(tokens, 'dashed')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "dashed",
+      }
+    `);
+    expect(textDecorationStyle(tokens, 'dotted')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "dotted",
+      }
+    `);
+    expect(textDecorationStyle(tokens, 'solid')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "solid",
+      }
+    `);
+    expect(textDecorationStyle(tokens, 'double')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationStyle": "double",
+      }
+    `);
+  });
+  test('Handles text-decoration-color', () => {
+    expect(textDecorationColor(tokens, 'red')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "red",
+      }
+    `);
+    expect(textDecorationColor(tokens, 'blue')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "blue",
+      }
+    `);
+    expect(textDecorationColor(tokens, 'gray400')).toMatchInlineSnapshot(`
+      Object {
+        "textDecorationColor": "#e3e3e3",
       }
     `);
   });


### PR DESCRIPTION
* Added support for text-decoration shorthand. Now we can pass in values like
```
textDecoration: underline dotted red;
```
or
```
 textDecoration: underline overline dotted gray400;
```

* Also added support for text-decoration-thickness in short hand properties 
```
 textDecoration: underline overline dotted gray400 5px;
```

* Tests updated for all of the above changes


Using this doc as a reference
https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration

Fix https://github.com/modulz/stitches/issues/142