### PR TITLE
cleanup types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "release": "yarn test && yarn build && lerna publish",
+    "release": "yarn build && yarn test && lerna publish",
     "build": "preconstruct build",
     "postinstall": "lerna bootstrap && preconstruct dev",
     "test:css": "yarn workspace @stitches/core run test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,6 @@
   "description": "The modern CSS-in-JS library",
   "main": "dist/core.cjs.js",
   "module": "dist/core.esm.js",
-  "types": "dist/declarations/src",
   "contributors": [
     "Christian Alfoni <christianalfoni@gmail.com>",
     "Pedro Duarte <pedro@modulz.app>",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,6 @@
   "description": "The modern CSS-in-JS library",
   "main": "dist/react.cjs.js",
   "module": "dist/react.esm.js",
-  "types": "dist/declarations/src",
   "contributors": [
     "Christian Alfoni <christianalfoni@gmail.com>",
     "Pedro Duarte <pedro@modulz.app>",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "lib": ["dom", "es2017"],
+    "preserveSymlinks": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "declaration": true,


### PR DESCRIPTION
Yesterday I added the types field because I saw that the types weren't working in codesandbox so I thought it was a global thing but today with more testing I found out that this issue is unrelated as I tested so many different formats of the type files and non of them worked on codesandbox but they worked for me locally and I was able to build design systems using the same published version that codesandbox wasn't able to read.

I got curious and looked at the network tab to see how codesandbox is querying types and noticed that there were a few errors in there related to the publish package as the requests sent to the codesandbox servers were throwing errors so will do a bit more research then open an issue there.

I'm suspecting that this might be with the types of structure that `preconstruct` produces.
for some reason, codesandbox's API isn't able to resolve them and is crashing or something 

this PR undoes the types field change as it's not needed and fixes #170 
I've also changed the order in which things are released so that when you run release you would be testing the built package and not the dev one