### PR TITLE
bugfix: check if the value passed to transition is a token and then use the token value

### DIFF
--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -168,22 +168,23 @@ export const font = createPropertyParser(
   }
 );
 
-export const transition = createPropertyParser(
+export const transition = (tokens: any, value: string) => {
   // The whole token is a transition, so need to grab it before passing in here
-  (_: any, css: any, value: any, index: any, chain: any) => {
-    if (matchString(value, unitMatch)) {
+  const tokenOrValue = tokens.transitions[value] || value;
+  return createPropertyParser((_: any, css: any, parsedValue: any, index: any, chain: any) => {
+    if (matchString(parsedValue, unitMatch)) {
       if (chain.findIndex((part: any) => part.match(unitMatch)) === index) {
-        css.transitionDuration = setChainedValue(css.transitionDuration, value);
+        css.transitionDuration = setChainedValue(css.transitionDuration, parsedValue);
       } else {
-        css.transitionDelay = setChainedValue(css.transitionDelay, value);
+        css.transitionDelay = setChainedValue(css.transitionDelay, parsedValue);
       }
-    } else if (matchString(value, easingMatch)) {
-      css.transitionTimingFunction = setChainedValue(css.transitionTimingFunction, value);
+    } else if (matchString(parsedValue, easingMatch)) {
+      css.transitionTimingFunction = setChainedValue(css.transitionTimingFunction, parsedValue);
     } else {
-      css.transitionProperty = setChainedValue(css.transitionProperty, value);
+      css.transitionProperty = setChainedValue(css.transitionProperty, parsedValue);
     }
-  }
-);
+  })(tokens, tokenOrValue);
+};
 
 export const margin = createPropertyParser((tokens: any, css: any, value: any, index: any) => {
   if (index === 0) {

--- a/packages/core/tests/shorthand-parser.test.ts
+++ b/packages/core/tests/shorthand-parser.test.ts
@@ -28,6 +28,7 @@ const tokens = {
   fonts: { main: 'potato-font' },
   borderWidths: { hairLine: '1px' },
   radii: { 1: '3px' },
+  transitions: { slow: 'all 1000ms', multiGroup: 'margin-right 2s, color 1s' },
 };
 
 // works
@@ -358,10 +359,22 @@ describe('Transition shorthand', () => {
             "transitionTimingFunction": "ease-out",
           }
       `);
+    expect(transition(tokens, 'slow')).toMatchInlineSnapshot(`
+          Object {
+            "transitionDuration": "1000ms",
+            "transitionProperty": "all",
+          }
+      `);
   });
   test('Handles multi-group transition shorthand', () => {
     // works
     expect(transition(tokens, 'margin-right 2s, color 1s')).toMatchInlineSnapshot(`
+      Object {
+        "transitionDuration": "2s,1s",
+        "transitionProperty": "margin-right,color",
+      }
+    `);
+    expect(transition(tokens, 'multiGroup')).toMatchInlineSnapshot(`
       Object {
         "transitionDuration": "2s,1s",
         "transitionProperty": "margin-right,color",


### PR DESCRIPTION
**What is the Issue?**
https://github.com/modulz/stitches/issues/175

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
This PR is a bug fix.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
In the current behavior, we do not set transition property values if a token is passed instead of a value.

<!-- if this is a feature change -->
**What is the new behavior?**
In the new behavior, we will first check if the value passed is a token and if it is then we will use the token value to set properties of transition.
In case it's a normal value, we will continue to use that value.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Issue Linked?