### PR TITLE
Add config breakpoints and improve tests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,11 +157,6 @@ const resolveBreakpointAndSelectorAndInlineMedia = (nestingPath: string[], confi
       }
       // breakpoints handling:
       if (breakpointOrSelector in config.breakpoints || breakpointOrSelector === MAIN_BREAKPOINT_ID) {
-        if (acc.breakpoint !== MAIN_BREAKPOINT_ID) {
-          throw new Error(
-            `@stitches/core - You are nesting the breakpoint "${breakpointOrSelector}" into "${acc.breakpoint}", that makes no sense? :-)`
-          );
-        }
         acc.breakpoint = breakpointOrSelector;
         return acc;
       }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1601,4 +1601,37 @@ describe('createCss', () => {
       ./*X*/_bznSbm/*X*/{padding-left:var(--space-1);}"
     `);
   });
+
+  test('Nesting config breakpoints into each other uses the deepest one for the rule', () => {
+    const css = createCss(
+      {
+        breakpoints: {
+          breakpointOne: (rule) => `@media(min-width:400px){${rule}}`,
+          breakpointTwo: (rule) => `@media(min-width:800px){${rule}}`,
+        },
+      },
+      null
+    );
+    const { styles } = css.getStyles(() => {
+      css({
+        breakpointOne: {
+          color: 'red',
+          breakpointTwo: {
+            color: 'blue',
+          },
+        },
+      }).toString();
+      return '';
+    });
+
+    expect(styles[2]).toMatchInlineSnapshot(`
+      "/* STITCHES:breakpointOne */
+      @media(min-width:400px){./*X*/_hmODGS/*X*/{color:red;}}"
+    `);
+
+    expect(styles[3]).toMatchInlineSnapshot(`
+      "/* STITCHES:breakpointTwo */
+      @media(min-width:800px){./*X*/_fQKrRn/*X*/{color:blue;}}"
+    `);
+  });
 });

--- a/packages/react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`styled Breakpoints work in variants 1`] = `
+{
+  "orderedAppliedStyles": [
+    "._initial_c_dzoaVP {color: red;}",
+    "._breakpointOne_h_hGDbbG {height: 10px;}",
+    "._breakpointTwo_h_cvoKvR {height: 20px;}"
+  ],
+  "props": {
+    "className": "_initial_c_dzoaVP _breakpointOne_h_hGDbbG _breakpointTwo_h_cvoKvR scid-kvQUME"
+  },
+  "children": [
+    "no variant"
+  ]
+}
+`;
+
+exports[`styled Breakpoints work in variants and when a responsive variant is passed ot the element 1`] = `
+{
+  "orderedAppliedStyles": [
+    "._initial_c_dzoaVP {color: red;}",
+    "._breakpointOne_h_ctNPWK {height: 100px;}",
+    "._breakpointTwo_h_clZhDR {height: 200px;}"
+  ],
+  "props": {
+    "className": "_breakpointOne_h_ctNPWK _breakpointTwo_h_clZhDR _initial_c_dzoaVP scid-cXpAaU"
+  },
+  "children": [
+    "with responsive variant"
+  ]
+}
+`;
+
+exports[`styled Breakpoints work in variants and when the variant is passed to the jsx element 1`] = `
+{
+  "orderedAppliedStyles": [
+    "._initial_c_dzoaVP {color: red;}",
+    "._breakpointOne_h_inlnue {height: 1000px;}",
+    "._breakpointTwo_h_dbWWOp {height: 2000px;}"
+  ],
+  "props": {
+    "className": "_breakpointOne_h_inlnue _breakpointTwo_h_dbWWOp _initial_c_dzoaVP scid-cXpAaU"
+  },
+  "children": [
+    "with variant"
+  ]
+}
+`;
+
 exports[`styled Handles compound variant 1`] = `
 {
   "orderedAppliedStyles": [


### PR DESCRIPTION
@peduarte This will fix #94 by making nested breakpoints override breakpoints with lower nesting as we've discussed before.
also, this improves testing for styled-components to include media queries styles (see `index.test.tsx.snap` for an example) and with this fixed, the structure should be in place to test styled-components so this in addition to the work that we did a few days ago around testing and building should fix #75 
