### PR TITLE
fix: Fix check against Deno

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -343,12 +343,19 @@ const composeIntoMap = (map: Map<string, IAtom>, atoms: (IAtom | IComposedAtom)[
   }
 };
 
+declare global {
+  interface Window {
+    Deno: any;
+  }
+}
+
 export const createTokens = <T extends ITokensDefinition>(tokens: T) => {
   return tokens;
 };
 export const createCss = <T extends TConfig>(
   _config: T,
-  env: Window | null = typeof window === 'undefined' ? null : window
+  // Check against Deno env explicitly #199
+  env: Window | null = typeof window === 'undefined' || window?.Deno ? null : window
 ): TCss<T> => {
   // pre-checked config to avoid checking these all the time
   // tslint:disable-next-line


### PR DESCRIPTION
Since I know `window` object exists on Deno and it has `Deno` object within it, I added a check based on that.

Of course the question is how to test this effectively. 😄 

Closes #199.