### PR TITLE
(suggestion) feat: withComponent API

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -80,6 +80,12 @@ export interface IStyledComponent<ComponentOrTag extends React.ElementType, Vari
     possibleValues: TCssWithBreakpoints<Config>
   ) => IStyledComponent<ComponentOrTag, Variants, Config>;
   /**
+   * witComponent typing:
+   */
+  withComponent: <NewComponentOrTag extends React.ElementType>(
+    component: NewComponentOrTag
+  ) => IStyledComponent<NewComponentOrTag, Variants, Config>;
+  /**
    * Default props typing:
    */
   defaultProps?: VariantASProps<Config, Variants> & { [k: string]: any };
@@ -290,6 +296,16 @@ export const createStyled = <Config extends TConfig>(
       evaluatedCompoundVariants.set(compundVariantsObject, evaluatedStyles);
       return StitchesComponent;
     };
+
+    (StitchesComponent as any).withComponent = (Element: React.ElementType) => {
+      if (typeof Element === 'string') {
+        currentAs = Element;
+        return styledInstance(baseAndVariantStyles);
+      }
+      currentAs = undefined;
+      return styledInstance(baseAndVariantStyles, Element);
+    };
+
     return StitchesComponent;
   };
 

--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -168,6 +168,17 @@ describe('styled', () => {
         .toJSON()
     ).toMatchSnapshot();
   });
+  test('Handles withComponent', () => {
+    const Base = styled('div', {});
+    const baseJson = renderer.create(<Base />).toJSON();
+
+    const Replaced = Base.withComponent('span');
+    const replacedJson = renderer.create(<Replaced />).toJSON();
+
+    expect(Base.displayName).toBe('styled(div)');
+    expect(Replaced.displayName).toBe('styled(span)');
+    expect({ ...replacedJson, type: null }).toEqual({ ...baseJson, type: null });
+  });
   test('It has default displayName when a string based element is passed', () => {
     const Button = styled('button', {});
     expect(Button.displayName).toBe('styled(button)');


### PR DESCRIPTION
Implemented `withComponent()` API 

- Emotion docs: https://emotion.sh/docs/styled#change-the-rendered-tag-using-withcomponent
- styled-comopnents docs: https://styled-components.com/docs/api#withcomponent

styled-components says it's going to be deprecated, but it's still worth it. It's easier to understand than as prop, and **TypeScript typing is more stable and fast.**

Uses can reuse styles while simultaneously **restricting bindings from being dynamically changed at runtime.**

It is a useful tool for defining components for the same styles and adds only 70 characters of code based on minified results. (even better result if it reuses code with the proxy below)

```tsx
const Icon = styled('svg', {
  width: '24px',
  height: '24px',
});

const FacebookIcon = Icon.withComponent(FacebookSvg);
const TwitterIcon = Icon.withComponent(TwitterSvg);

<FacebookIcon />
<TwitterIcon />
{/* vs */}
<Icon as={FacebookSvg} />
<Icon as={TwitterSvg} />

const Button = styled('button', {
});
const ButtonLink = Button.withComponent(Link);

<ButtonLink />
{/* vs */}
<Button as={Link}/>
```