### PR TITLE
refactor: jest configuration

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,36 +1,8 @@
-const semver = require("semver");
-
-function getSupportedTypescriptTarget() {
-  const nodeVersion = process.versions.node;
-
-  if (semver.gt(nodeVersion, "10.0.0")) {
-    return "es2018";
-  } else if (semver.gt(nodeVersion, "7.6.0")) {
-    return "es2017";
-  } else if (semver.gt(nodeVersion, "7.0.0")) {
-    return "es2016";
-  } else if (semver.gt(nodeVersion, "6.0.0")) {
-    return "es2015";
-  } else {
-    return "es5";
-  }
-}
-
 module.exports = {
-  roots: ["<rootDir>/src", "<rootDir>/tests"],
-  testURL: "http://localhost",
-  preset: "ts-jest",
-  testRegex: "(/tests/.*.(test|spec)).(jsx?|tsx?)$",
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  collectCoverageFrom: ["src/**/*.{t,j}s?(x)", "!src/**/*.d.ts"],
-  collectCoverage: true,
-  coveragePathIgnorePatterns: ["(tests/.*.mock).(jsx?|tsx?)$"],
+  preset: 'ts-jest',
+  testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  collectCoverageFrom: ['**/*.{t,j}s?(x)', '!**/*.d.ts', '!dist', '!**/dist/**'],
+  coveragePathIgnorePatterns: ['/node_modules/','/dist/','(tests/.*.mock).(jsx?|tsx?)$'],
   verbose: true,
-  globals: {
-    "ts-jest": {
-      tsConfig: {
-        target: getSupportedTypescriptTarget(),
-      },
-    },
-  },
 };

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,6 +3,6 @@ module.exports = {
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   collectCoverageFrom: ['**/*.{t,j}s?(x)', '!**/*.d.ts', '!dist', '!**/dist/**'],
-  coveragePathIgnorePatterns: ['/node_modules/','/dist/','(tests/.*.mock).(jsx?|tsx?)$'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '(tests/.*.mock).(jsx?|tsx?)$'],
   verbose: true,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ const base = require("./jest.config.base.js");
 
 module.exports = {
   ...base,
-  projects: ["<rootDir>/packages/*/jest.config.js"],
+  projects: ["<rootDir>/packages/*"],
   coverageDirectory: "<rootDir>/coverage/",
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
-const base = require("./jest.config.base.js");
+const base = require('./jest.config.base.js');
 
 module.exports = {
   ...base,
-  projects: ["<rootDir>/packages/*"],
-  coverageDirectory: "<rootDir>/coverage/",
+  projects: ['<rootDir>/packages/*'],
+  coverageDirectory: '<rootDir>/coverage/',
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postinstall": "lerna bootstrap && preconstruct dev",
     "test:css": "yarn workspace @stitches/core run test",
     "test:react": "yarn workspace @stitches/react run test",
-    "test": "jest --runInBand --ci --coverage"
+    "test": "jest --runInBand --ci --coverage",
+    "test:watch": "jest --watch --updateSnapshot"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "lerna bootstrap && preconstruct dev",
     "test:css": "yarn workspace @stitches/core run test",
     "test:react": "yarn workspace @stitches/react run test",
-    "test": "yarn test:css && yarn test:react"
+    "test": "jest --runInBand --ci --coverage"
   },
   "workspaces": [
     "packages/*"
@@ -28,7 +28,6 @@
     "lint-staged": "^9.5.0",
     "prettier": "^2.0.4",
     "rimraf": "^3.0.2",
-    "semver": "^7.3.0",
     "ts-jest": "~25.3.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -2,6 +2,7 @@ const base = require('../../jest.config.base.js');
 
 module.exports = {
   ...base,
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
   name: '@atomica/css',
   displayName: 'css',
 };

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,8 +1,8 @@
 const base = require('../../jest.config.base.js');
+const packageJson = require('./package.json');
 
 module.exports = {
   ...base,
-  roots: ["<rootDir>/src", "<rootDir>/tests"],
-  name: '@atomica/css',
-  displayName: 'css',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  displayName: packageJson.name,
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,8 +33,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "tslint --project tsconfig.json --format stylish",
     "format": "prettier '**/*.{md,js,jsx,json,ts,tsx}' --write",
-    "test": "jest --env=jsdom --coverage",
-    "test:watch": "node ../../node_modules/jest/bin/jest.js --env=jsdom --watch --updateSnapshot",
+    "test": "jest",
+    "test:watch": "jest --watch --updateSnapshot",
     "posttest": "npm run typecheck && npm run lint",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -2,6 +2,7 @@ const base = require('../../jest.config.base.js');
 
 module.exports = {
   ...base,
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
   name: '@atomica/css',
   displayName: 'css',
 };

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,8 +1,8 @@
 const base = require('../../jest.config.base.js');
+const packageJson = require('./package.json');
 
 module.exports = {
   ...base,
-  roots: ["<rootDir>/src", "<rootDir>/tests"],
-  name: '@atomica/css',
-  displayName: 'css',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  displayName: packageJson.name,
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,8 +32,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "tslint --project tsconfig.json --format stylish",
     "format": "prettier '**/*.{md,js,jsx,json,ts,tsx}' --write",
-    "test": "jest --env=jsdom --coverage",
-    "test:watch": "node ../../node_modules/jest/bin/jest.js --env=jsdom --watch --updateSnapshot",
+    "test": "jest",
+    "test:watch": "jest --watch --updateSnapshot",
     "posttest": "npm run typecheck && npm run lint",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,11 +7602,6 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^7.3.0:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
- allows Jest to be run from the root of the project.  As Jest supports [`projects`](https://jestjs.io/docs/en/configuration#projects-arraystring--projectconfig) we can use that to run Jest from root of the project folder. _"This is great for monorepos"_. 
  - Also allows the usage of [VSCode Extension Jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) to work without custom configuration.

- removed what appears to be a legacy node version logic in [`jest.config.base.js`](https://github.com/modulz/stitches/compare/canary...andykenward:jest-config?expand=1#diff-66d3521f5e9f81934077fdd6653d0901L1-L18). We can use the projects tsconfig.json. Perhaps we need to define the package.json [`engines`](https://docs.npmjs.com/files/package.json#engines) for what version of node & yarn this project supports.
- generates coverage only on root `yarn test` and not in each package folder
- As yarn workspaces is used in the project there should be no need to reference Jest from the node_modules directory for the `test:watch` cli. ~~`node ../../node_modules/jest/bin/jest.js`~~ becomes `jest`.
- Removed some config and arguments that are already defined as the defaults for jest. e.g `--env=jsdom`
- Added root cli `yarn test:watch` so you can watch all test files in project.
- fix jest displayName to match package name.