### PR TITLE
Add `as` defaultProps types and tests

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -91,7 +91,7 @@ export interface IStyledComponent<ComponentOrTag extends React.ElementType, Vari
   /**
    * Default props typing:
    */
-  defaultProps?: VariantASProps<Config, Variants> & { [k: string]: any };
+  defaultProps?: VariantASProps<Config, Variants> & { as?: React.ElementType } & { [k: string]: any };
   /**
    * DisplayName typing:
    */
@@ -341,3 +341,13 @@ function evaluateStylesForAllBreakpoints(styleObject: any, configBreakpoints: an
   }
   return breakpoints;
 }
+
+const { styled } = createStyled({});
+
+const Button = styled.button({
+  backgroundColor: 'red',
+});
+
+Button.defaultProps = {
+  as: 'div',
+};

--- a/packages/react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/index.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`styled Breakpoints work in variants 1`] = `
 {
   "orderedAppliedStyles": [
-    "._initial_c_dzoaVP {color: red;}",
-    "._breakpointOne_h_hGDbbG {height: 10px;}",
-    "._breakpointTwo_h_cvoKvR {height: 20px;}"
+    "._initial_c_vfarC {color: red;}",
+    "._breakpointOne_h_KwWJf {height: 10px;}",
+    "._breakpointTwo_h_hiyRrM {height: 20px;}"
   ],
   "props": {
-    "className": "_initial_c_dzoaVP _breakpointOne_h_hGDbbG _breakpointTwo_h_cvoKvR scid-kvQUME"
+    "className": "_initial_c_vfarC _breakpointOne_h_KwWJf _breakpointTwo_h_hiyRrM scid-kvQUME"
   },
   "children": [
     "no variant"
@@ -19,12 +19,12 @@ exports[`styled Breakpoints work in variants 1`] = `
 exports[`styled Breakpoints work in variants and when a responsive variant is passed ot the element 1`] = `
 {
   "orderedAppliedStyles": [
-    "._initial_c_dzoaVP {color: red;}",
-    "._breakpointOne_h_ctNPWK {height: 100px;}",
-    "._breakpointTwo_h_clZhDR {height: 200px;}"
+    "._initial_c_vfarC {color: red;}",
+    "._breakpointOne_h_dDcWdv {height: 100px;}",
+    "._breakpointTwo_h_dPiPAc {height: 200px;}"
   ],
   "props": {
-    "className": "_breakpointOne_h_ctNPWK _breakpointTwo_h_clZhDR _initial_c_dzoaVP scid-cXpAaU"
+    "className": "_breakpointOne_h_dDcWdv _breakpointTwo_h_dPiPAc _initial_c_vfarC scid-cXpAaU"
   },
   "children": [
     "with responsive variant"
@@ -35,12 +35,12 @@ exports[`styled Breakpoints work in variants and when a responsive variant is pa
 exports[`styled Breakpoints work in variants and when the variant is passed to the jsx element 1`] = `
 {
   "orderedAppliedStyles": [
-    "._initial_c_dzoaVP {color: red;}",
-    "._breakpointOne_h_inlnue {height: 1000px;}",
-    "._breakpointTwo_h_dbWWOp {height: 2000px;}"
+    "._initial_c_vfarC {color: red;}",
+    "._breakpointOne_h_kgNeVv {height: 1000px;}",
+    "._breakpointTwo_h_fptqfg {height: 2000px;}"
   ],
   "props": {
-    "className": "_breakpointOne_h_inlnue _breakpointTwo_h_dbWWOp _initial_c_dzoaVP scid-cXpAaU"
+    "className": "_breakpointOne_h_kgNeVv _breakpointTwo_h_fptqfg _initial_c_vfarC scid-cXpAaU"
   },
   "children": [
     "with variant"
@@ -51,11 +51,11 @@ exports[`styled Breakpoints work in variants and when the variant is passed to t
 exports[`styled Handles compound variant 1`] = `
 {
   "orderedAppliedStyles": [
-    "._bieopk {background-color: red;}",
-    "._dtTvho {height: 60px;}"
+    "._gwFOTp {background-color: red;}",
+    "._cDgDLB {height: 60px;}"
   ],
   "props": {
-    "className": "_dtTvho _bieopk scid-URbJg"
+    "className": "_cDgDLB _gwFOTp scid-URbJg"
   },
   "children": [
     "not compound"
@@ -66,11 +66,11 @@ exports[`styled Handles compound variant 1`] = `
 exports[`styled Handles compound variant 2`] = `
 {
   "orderedAppliedStyles": [
-    "._bSHlld {height: 30px;}",
-    "._hEGtPv {background-color: compoundColor;}"
+    "._izHeYc {height: 30px;}",
+    "._eBRzFG {background-color: compoundColor;}"
   ],
   "props": {
-    "className": "_hEGtPv _bSHlld scid-URbJg"
+    "className": "_eBRzFG _izHeYc scid-URbJg"
   },
   "children": [
     "compound"
@@ -81,11 +81,11 @@ exports[`styled Handles compound variant 2`] = `
 exports[`styled Handles css prop 1`] = `
 {
   "orderedAppliedStyles": [
-    "._iBRUhC {background-color: gray;}",
-    "._dzoaVP {color: red;}"
+    "._fNPZtH {background-color: gray;}",
+    "._vfarC {color: red;}"
   ],
   "props": {
-    "className": "_dzoaVP _iBRUhC scid-dmZJpl"
+    "className": "_vfarC _fNPZtH scid-dmZJpl"
   },
   "children": [
     "hello world"
@@ -96,11 +96,11 @@ exports[`styled Handles css prop 1`] = `
 exports[`styled Handles css prop 2`] = `
 {
   "orderedAppliedStyles": [
-    "._iBRUhC {background-color: gray;}",
-    "._dzoaVP {color: red;}"
+    "._fNPZtH {background-color: gray;}",
+    "._vfarC {color: red;}"
   ],
   "props": {
-    "className": "_dzoaVP _iBRUhC scid-dmZJpl"
+    "className": "_vfarC _fNPZtH scid-dmZJpl"
   },
   "children": [
     "hello world"
@@ -111,10 +111,10 @@ exports[`styled Handles css prop 2`] = `
 exports[`styled It handles variants with a numeric value of 0 1`] = `
 {
   "orderedAppliedStyles": [
-    "._jefWVX {height: 1px;}"
+    "._NkcBC {height: 1px;}"
   ],
   "props": {
-    "className": "_jefWVX scid-fUwIQk"
+    "className": "_NkcBC scid-fUwIQk"
   },
   "children": [
     "height should equal '1px'"
@@ -125,10 +125,10 @@ exports[`styled It handles variants with a numeric value of 0 1`] = `
 exports[`styled Renders basic component 1`] = `
 {
   "orderedAppliedStyles": [
-    "._bOFHNE div {font-size: 18px;}"
+    "._dawVaV div {font-size: 18px;}"
   ],
   "props": {
-    "className": "hi _bOFHNE scid-dIyoRL"
+    "className": "hi _dawVaV scid-dIyoRL"
   },
   "children": [
     "hello world"
@@ -139,10 +139,10 @@ exports[`styled Renders basic component 1`] = `
 exports[`styled renders component with variant 1`] = `
 {
   "orderedAppliedStyles": [
-    "._iBRUhC {background-color: gray;}"
+    "._fNPZtH {background-color: gray;}"
   ],
   "props": {
-    "className": "_iBRUhC scid-gFxMiu"
+    "className": "_fNPZtH scid-gFxMiu"
   },
   "children": [
     "hello world"
@@ -153,10 +153,10 @@ exports[`styled renders component with variant 1`] = `
 exports[`styled renders component with variant 2`] = `
 {
   "orderedAppliedStyles": [
-    "._bieopk {background-color: red;}"
+    "._gwFOTp {background-color: red;}"
   ],
   "props": {
-    "className": "_bieopk scid-gFxMiu"
+    "className": "_gwFOTp scid-gFxMiu"
   },
   "children": [
     "hello world"
@@ -167,10 +167,10 @@ exports[`styled renders component with variant 2`] = `
 exports[`styled renders component with variant 3`] = `
 {
   "orderedAppliedStyles": [
-    "._YfjLh {background-color: blue;}"
+    "._htDnsg {background-color: blue;}"
   ],
   "props": {
-    "className": "_YfjLh scid-gFxMiu"
+    "className": "_htDnsg scid-gFxMiu"
   },
   "children": [
     "hello world"

--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -318,4 +318,17 @@ describe('styled', () => {
     });
     expect(renderer.create(<Button size={0}>height should equal '1px'</Button>).toJSON()).toMatchSnapshot();
   });
+
+  test('it has the as prop typed correctly inside defaultProps', () => {
+    const Button = styled.button({});
+
+    Button.defaultProps = {
+      as: 'div',
+    };
+
+    Button.defaultProps = {
+      // @ts-expect-error
+      as: 'potato',
+    };
+  });
 });


### PR DESCRIPTION
Fixes #223

Note: there is diff noise in the tests related to the changes we did in the core package for the comma-separated rules and ampersand in #245  