### PR TITLE
test(#253): add test for boolean compound variables

### DIFF
--- a/packages/react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/index.test.tsx.snap
@@ -165,6 +165,47 @@ exports[`styled Renders composed component 1`] = `
 }
 `;
 
+exports[`styled handles boolean compound variant 1`] = `
+Array [
+  {
+  "orderedAppliedStyles": [
+    "._oRObr {font-weight: bold;}",
+    "._kXqcij {text-decoration-line: underline;}"
+  ],
+  "props": {
+    "className": "_kXqcij _oRObr scid-idZRwg"
+  },
+  "children": [
+    "bold, underline"
+  ]
+},
+  {
+  "orderedAppliedStyles": [
+    "._ldesWJ {text-style: italic;}",
+    "._UNaLq {text-transform: uppercase;}"
+  ],
+  "props": {
+    "className": "_UNaLq _ldesWJ scid-idZRwg"
+  },
+  "children": [
+    "italic, uppercase"
+  ]
+},
+  {
+  "orderedAppliedStyles": [
+    "._ldesWJ {text-style: italic;}",
+    "._oRObr {font-weight: bold;}"
+  ],
+  "props": {
+    "className": "_ldesWJ _oRObr scid-idZRwg"
+  },
+  "children": [
+    "italic, bold"
+  ]
+},
+]
+`;
+
 exports[`styled renders component with variant 1`] = `
 {
   "orderedAppliedStyles": [

--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -187,6 +187,29 @@ describe('styled', () => {
         .toJSON()
     ).toMatchSnapshot();
   });
+
+  test('handles boolean compound variant', () => {
+    const Button = styled('button', {
+      variants: { bold: { true: { fontWeight: 'bold' } }, italic: { true: { textStyle: 'italic' } } },
+    })
+      .compoundVariant({ bold: true, italic: false }, { textDecoration: 'underline' })
+      .compoundVariant({ bold: false, italic: true }, { textTransform: 'uppercase' });
+    Button.defaultProps = { bold: false, italic: false };
+    expect(
+      renderer
+        .create(
+          <>
+            <Button bold>bold, underline</Button>
+            <Button italic>italic, uppercase</Button>
+            <Button bold italic>
+              italic, bold
+            </Button>
+          </>
+        )
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+
   test('It has default displayName when a string based element is passed', () => {
     const Button = styled('button', {});
     expect(Button.displayName).toBe('styled(button)');


### PR DESCRIPTION
I wanted to fix #253 but it was already working in latest canary 🤩

So I added a test for it.