### PR TITLE
Add way to extract props & variants types

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -74,6 +74,7 @@ export interface IStyledComponent<ComponentOrTag extends React.ElementType, Vari
     // e.g. some HTML elements have `size` attribute. And when you combine
     // both types (native and variant props) the common props become
     // unusable (in typing-wise)
+
     props: MergeElementProps<As, VariantASProps<Config, Variants>> & {
       as?: As;
       css?: TCssWithBreakpoints<Config>;
@@ -118,6 +119,20 @@ export type TProxyStyledElements<Config extends TConfig> = {
     a: BaseAndVariantStyles | TComponentStylesObject<Config>
   ) => IStyledComponent<key, TExtractVariants<BaseAndVariantStyles>, Config>;
 };
+
+export type TExtractVariantProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
+  ? VariantASProps<G, V>
+  : never;
+
+export type TStyledComponentProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
+  ? MergeElementProps<T, VariantASProps<G, V>> & {
+      as?: T;
+      css?: TCssWithBreakpoints<G>;
+      className?: string;
+      children?: any;
+    }
+  : never;
+
 /**
  * Styled Components creator Type.
  * ie: styled.div(styles) | styled('div', {styles})

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -39,6 +39,13 @@ export type CastStringToBoolean<Val> = Val extends 'true' | 'false' ? boolean | 
 export type CastNumberToString<Val> = Val extends number ? string & {} : never;
 
 /**
+ * Extract variant props from Stitches components
+ */
+export type ExtractVariantProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
+  ? VariantASProps<G, V>
+  : never;
+
+/**
  * Takes a variants object and converts it to the correct type information for usage in props
  */
 export type VariantASProps<Config extends TConfig, VariantsObj> = {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -41,8 +41,19 @@ export type CastNumberToString<Val> = Val extends number ? string & {} : never;
 /**
  * Extract variant props from Stitches components
  */
-export type ExtractVariantProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
-  ? VariantASProps<G, V>
+export type StitchesVariants<C> = C extends IStyledComponent<infer T, infer V, infer G> ? VariantASProps<G, V> : never;
+
+/**
+ * Extracts the props types of a stitches component
+ *
+ */
+export type StitchesComponentProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
+  ? MergeElementProps<T, VariantASProps<G, V>> & {
+      as?: T;
+      css?: TCssWithBreakpoints<G>;
+      className?: string;
+      children?: any;
+    }
   : never;
 
 /**

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -65,7 +65,17 @@ type MergeElementProps<As extends React.ElementType, Props extends object = {}> 
  * 1. Props of a styled component
  * 2. The compoundVariants function typings
  */
-export interface IStyledComponent<ComponentOrTag extends React.ElementType, Variants, Config extends TConfig> {
+export interface IStyledComponent<
+  ComponentOrTag extends React.ElementType,
+  Variants,
+  Config extends TConfig
+> extends React.FC<
+    MergeElementProps<ComponentOrTag, VariantASProps<Config, Variants>> & {
+      css?: TCssWithBreakpoints<Config>;
+      className?: string;
+      children?: any;
+    }
+  > {
   /**
    * Props of a styled component
    */
@@ -74,7 +84,6 @@ export interface IStyledComponent<ComponentOrTag extends React.ElementType, Vari
     // e.g. some HTML elements have `size` attribute. And when you combine
     // both types (native and variant props) the common props become
     // unusable (in typing-wise)
-
     props: MergeElementProps<As, VariantASProps<Config, Variants>> & {
       as?: As;
       css?: TCssWithBreakpoints<Config>;
@@ -89,16 +98,12 @@ export interface IStyledComponent<ComponentOrTag extends React.ElementType, Vari
     compoundVariants: VariantASProps<Config, Variants>,
     possibleValues: TCssWithBreakpoints<Config>
   ) => IStyledComponent<ComponentOrTag, Variants, Config>;
-  /**
-   * Default props typing:
-   */
-  defaultProps?: VariantASProps<Config, Variants> & { [k: string]: any };
-  /**
-   * DisplayName typing:
-   */
-  displayName?: string;
-}
 
+  /**
+   * @deprecated
+   */
+  defaultProps?: never;
+}
 /** Typed css with tokens and breakpoints */
 export type TCssWithBreakpoints<Config extends TConfig> = TCssProp<Config> &
   { [key in BreakPointsKeys<Config>]?: TCssProp<Config> };
@@ -119,19 +124,6 @@ export type TProxyStyledElements<Config extends TConfig> = {
     a: BaseAndVariantStyles | TComponentStylesObject<Config>
   ) => IStyledComponent<key, TExtractVariants<BaseAndVariantStyles>, Config>;
 };
-
-export type TExtractVariantProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
-  ? VariantASProps<G, V>
-  : never;
-
-export type TStyledComponentProps<C> = C extends IStyledComponent<infer T, infer V, infer G>
-  ? MergeElementProps<T, VariantASProps<G, V>> & {
-      as?: T;
-      css?: TCssWithBreakpoints<G>;
-      className?: string;
-      children?: any;
-    }
-  : never;
 
 /**
  * Styled Components creator Type.


### PR DESCRIPTION
Adds ExtractVariantProps generic util that allows extracting the variant props out of stitches components
Allows React.ComponentProps to work with stitches components - Fixes #248 