### PR TITLE
Preserve Custom Properties

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -266,7 +266,7 @@ const processStyleObject = (
  * borderColor => border-color
  */
 const hyphenAndVendorPrefixCssProp = (cssProp: string, vendorProps: any[], vendorPrefix: string) => {
-  const isVendorPrefixed = cssProp[0] === cssProp[0].toUpperCase();
+  const isVendorPrefixed = /^[A-Z]/.test(cssProp);
   let cssHyphenProp = cssProp
     .split(/(?=[A-Z])/)
     .map((g) => g.toLowerCase())

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -334,6 +334,13 @@ describe('createCss: mixed(SSR & Client)', () => {
     );
   });
 
+  test('should preserve custom properties', () => {
+    const css = createCss({}, null);
+    const atom = (css({ '--magic': 'red' }) as any).atoms[0];
+
+    expect(atom.cssHyphenProp).toMatchInlineSnapshot(`"--magic"`);
+  });
+
   test('should allow utils', () => {
     const css = createCss(
       {


### PR DESCRIPTION
This changes the internal [`hyphenAndVendorPrefixCssProp`](https://github.com/modulz/stitches/blob/v0.0.3-canary.3/packages/core/src/index.ts#L264-L281) function to a prevent `isVendorPrefixed` from returning a false positive when evaluating a custom property. It also adds a custom property test that would currently fail.

### Current Behavior

A custom property like `--whatever` is transformed into `---whatever`.

This is caused by a vendor prefix check that checks for uppercase letters and falsely matches dashes.

```js
const isVendorPrefixed = cssProp[0] === cssProp[0].toUpperCase()

// ( `-` === `-`.toUpperCase() ) === true // 😿🧻
```

### Proposed Behavior

A custom property like `--whatever` remains `--whatever`.

The vendor prefix check would explicitly check for an uppercase letter.

```js
const isVendorPrefixed = /^[A-Z]/.test(cssProp);

// /^[A-Z]/.test(`-`) === false // 😸 🎉 
```

---

Resolves #267