### PR TITLE
Add type helpers

### DIFF
--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -337,4 +337,16 @@ describe('styled', () => {
     });
     expect(renderer.create(<Button size={0}>height should equal '1px'</Button>).toJSON()).toMatchSnapshot();
   });
+
+  test('It throws an error when trying to access the __TYPE_HELPERS outside of types', () => {
+    let err;
+    try {
+      const dontDoThis = styled.__TYPE_HELPERS;
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toMatchInlineSnapshot(
+      `[Error: __TYPE_HELPERS is a fake prop is intended as a helper to give access the inferred typescript types from the config and not to be used outside that.]`
+    );
+  });
 });


### PR DESCRIPTION
Fixes #221
Fixes #129 

This introduces three helpers that should be documented:
- `StitchesTokenKeys`: takes a tokens object then allows you to access each scale keys
- `StitchesComponentStyles`: takes a config and returns the type of the styles which then you could use to type your style objects in a stitches safe way
- `StitchesTypes`: combines the above two

**Example usage:**
```ts
// Using the generics
const tokens =  {
    colors: {
      $red100: 'tomato'
    }
  } as const

type StitchesTokens = StitchesTokenKeys<typeof tokens>

const config = {
  tokens,
  utils: {
    p: (val: StitchesTokens['space']) => ({})
  }

} as const

type StitchesStyles = StitchesComponentStyles<typeof config>

const {styled} = createStyled(config)


const styleObj: StitchesStyles = {
  backgroundColor: '$red100'
}

const Button = styled.button({
  ...styleObj
})
```

Also, one thing that got added was a private prop `__TYPE_HELPERS` only intended to extract the types of a styled instance (in case one doesn’t want to extract tokens into separate constants and use the above generics.

**Example usage:** 


```ts
// with the __TYPE_HELPERS
const {styled} = createStyled({
  tokens: {
    colors: {
      $red100: 'tomato'
    }
  }
})

type StitchesTypeHelpers = typeof styled.__TYPE_HELPERS
type StitchesStyles = StitchesTypeHelpers['css']

const styleObj: StitchesStyles = {
  backgroundColor: '$red100'
}

const Button = styled.button({
  ...styleObj
})
```

Trying to access `styled.__TYPE_HELPERS` in js (not as a typescript type) will throw an error informing the user that this is just a type helper

@peduarte Please have a look and let me know whether this going to be sufficient or if some modifications are needed
