### PR TITLE
Reduce the usage of TypeScript any in codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# VSCode config folder
+.vscode

--- a/packages/core/src/shorthand-parser/index.ts
+++ b/packages/core/src/shorthand-parser/index.ts
@@ -27,7 +27,6 @@ const createPropertyParser = (type: any) => (tokens: any, value: any) => {
   const tmpTokens = typeof value === 'number' ? emptyTokens : tokens;
 
   chains.forEach((chain, chainIndex) => {
-    // tslint:disable-next-line
     chain.forEach((_value, index) => {
       type(tmpTokens, css, _value, index, chain, chainIndex, chains);
     });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,7 +95,7 @@ export const ATOM = Symbol('ATOM');
 export interface IAtom {
   id: string;
   cssHyphenProp: string;
-  value: string;
+  value: string | IKeyframesAtom;
   selector: string;
   breakpoint: string;
   _isGlobal?: boolean;
@@ -403,14 +403,16 @@ export type TCssProperties<T extends TConfig> = T['breakpoints'] extends object
   : TRecursiveCss<T> & TRecursiveUtils<T>;
 
 export interface TCss<T extends TConfig> {
-  (...styles: (TCssProperties<T> | string | boolean | null | undefined)[]): string;
+  (
+    ...styles: (TCssProperties<T> | IAtom | { [key: string]: IKeyframesAtom } | string | boolean | null | undefined)[]
+  ): IComposedAtom;
   getStyles: (
     callback: () => any
   ) => {
     styles: string[];
     result: any;
   };
-  keyframes: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => string;
+  keyframes: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => IKeyframesAtom;
   global: (definition: Record<string, TCssProperties<T>>) => () => string;
   theme: (
     theme: Partial<
@@ -418,7 +420,9 @@ export interface TCss<T extends TConfig> {
         [TO in keyof T['tokens']]: Partial<T['tokens'][TO]>;
       }
     >
-  ) => string;
+  ) => IThemeAtom;
+  dispose: () => void;
+  _config: () => TConfig<true>;
 }
 
 export interface ISheet {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -19,7 +19,7 @@ import {
   textDecoration,
   flex,
 } from './shorthand-parser';
-import { IBreakpoints, ICssPropToToken, ISheet } from './types';
+import { IBreakpoints, ICssPropToToken, ISheet, ATOM, IAtom, IComposedAtom } from './types';
 
 export const MAIN_BREAKPOINT_ID = 'initial';
 export type TMainBreakPoint = typeof MAIN_BREAKPOINT_ID;
@@ -270,4 +270,23 @@ function generateAlphabeticName(code: number): string {
   }
 
   return (getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2');
+}
+
+/**
+ * Type Guard for an IAtom object. As this is only checking for Symbol ATOM on the object.
+ * We might need to narrow this as there are other objects with ATOM.
+ * - IAtom
+ * - IThemeAtom
+ * - IComposedAtom
+ * - IKeyframesAtom
+ */
+export function isAtom(item: any): item is IAtom {
+  return item[ATOM];
+}
+
+/**
+ * Type Guard for IComposedAtom.
+ */
+export function isComposedAtom(item: any): item is IComposedAtom {
+  return item[ATOM] && item.atoms;
 }

--- a/packages/core/tests/ssr-only.test.ts
+++ b/packages/core/tests/ssr-only.test.ts
@@ -48,7 +48,7 @@ describe('createCss: SSR', () => {
 
   test('should regenerate styles when server side rendered', () => {
     const css = createCss({}, null);
-    const atoms = css({ color: 'red' }) as any;
+    const atoms = css({ color: 'red' });
     // this acts like a request on the server
     const { styles } = css.getStyles(() => {
       atoms.toString();
@@ -81,7 +81,7 @@ describe('createCss: SSR', () => {
       '0%': { opacity: '0' },
       '100%': { opacity: '1' },
     });
-    const atoms = css({ animation: `${fade} 333ms` }) as any;
+    const atoms = css({ animation: `${fade} 333ms` });
     // this acts like a request on the server
     const { styles } = css.getStyles(() => {
       atoms.toString();

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -6,6 +6,7 @@ import {
   TMainBreakPoint,
   createCss,
   hashString,
+  IComposedAtom,
 } from '@stitches/core';
 export { _ATOM } from '@stitches/core';
 import * as React from 'react';
@@ -204,7 +205,7 @@ export const createStyled = <Config extends TConfig>(
         // eslint-disable-next-line
         const memoStyled = React.useMemo(() => props.css, []); // We want this to only eval once
         if (memoStyled !== props.css && !hasWarnedInlineStyle) {
-          // tslint:disable-next-line
+          // tslint:disable-next-line: no-console
           console.warn(
             '@stitches/react : The css prop should ideally not be dynamic. Define it outside your component using the css composer, or use a memo hook'
           );
@@ -265,7 +266,7 @@ export const createStyled = <Config extends TConfig>(
 
       // By default we don't stringify the classname (composition), so that
       // the children Stitches component is responsible for the final composition
-      let className = css(stitchesComponentId, ...compositions, props.className);
+      let className: IComposedAtom | string = css(stitchesComponentId, ...compositions, props.className);
 
       // If we're not wrapping a Stitches component,
       // we ensure the classname is stringified
@@ -317,7 +318,7 @@ export const createStyled = <Config extends TConfig>(
     return StitchesComponent;
   };
 
-  // tslint:disable-next-line
+  // tslint:disable-next-line: no-empty
   const styledProxy = new Proxy(() => {}, {
     get(_, prop) {
       if (prop === 'Box') {
@@ -346,7 +347,7 @@ function evaluateStylesForAllBreakpoints(styleObject: any, configBreakpoints: an
     [MAIN_BREAKPOINT_ID]: css(styleObject),
   };
   if (configBreakpoints) {
-    // tslint:disable-next-line
+    // tslint:disable-next-line: forin
     for (const breakpoint in configBreakpoints) {
       breakpoints[breakpoint] = css({
         [breakpoint]: styleObject,

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -6,7 +6,6 @@ import {
   TMainBreakPoint,
   createCss,
   hashString,
-  IComposedAtom,
 } from '@stitches/core';
 export { _ATOM } from '@stitches/core';
 import * as React from 'react';
@@ -266,14 +265,12 @@ export const createStyled = <Config extends TConfig>(
 
       // By default we don't stringify the classname (composition), so that
       // the children Stitches component is responsible for the final composition
-      let className: IComposedAtom | string = css(stitchesComponentId, ...compositions, props.className);
+      const composedAtom = css(stitchesComponentId, ...compositions, props.className);
 
       // If we're not wrapping a Stitches component,
       // we ensure the classname is stringified
       // https://github.com/modulz/stitches/issues/229
-      if (!(Component as any).__isStitchesComponent) {
-        className = className.toString();
-      }
+      const className = !(Component as any).__isStitchesComponent ? composedAtom.toString() : composedAtom;
 
       return React.createElement(Component, {
         ...propsWithoutVariantsAndCssProp,

--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -24,12 +24,12 @@ const resolveRules = (rule: CSSRule, resolvedRules: CSSStyleRule[] = []) => {
 const getMatchingRulesForClasses = (classesAsArray: string[]) => {
   const orderedAppliedStyles: string[] = [];
   for (let i = 0; i < window.document.styleSheets.length; i++) {
-    const sheetRules = window.document.styleSheets[i].cssRules as any;
+    const sheetRules = window.document.styleSheets[i].cssRules;
     for (let b = 0; b < sheetRules.length; b++) {
       const rule = sheetRules[b];
       const resolvedRules = resolveRules(rule);
       resolvedRules.forEach((cssRule) => {
-        classesAsArray.forEach((atomClass: any) => {
+        classesAsArray.forEach((atomClass) => {
           if (cssRule.selectorText.includes(atomClass)) {
             orderedAppliedStyles.push(cssRule.cssText);
           }
@@ -73,7 +73,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  (css as any).dispose();
+  css.dispose();
 });
 
 describe('styled', () => {
@@ -230,7 +230,7 @@ describe('styled', () => {
       },
     });
     expect(renderer.create(<Button>no variant</Button>).toJSON()).toMatchSnapshot();
-    (_css as any).dispose();
+    _css.dispose();
   });
 
   test('Breakpoints work in variants and when the variant is passed to the jsx element', () => {


### PR DESCRIPTION
Relates to #118 

Have made a start at trying to reduce the uage of TypeScript `any` and castings of typings used in the codebase.

 Started with `createCss` [`cssInstance`](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-55646d75364ce42cdb84abec1a1531ccR613-R636) in the core package. As this was disconnected from the interface typings of  [TCss](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-2991521f751aa9cf68976ceef512e19aR405-R426)

I've add a couple of TypeScript [User-Defined Type Guards](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) to help with `[ATOM]` objects. 
Example of usage [here](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-55646d75364ce42cdb84abec1a1531ccL420-R427)
- [`isAtom`](https://github.com/modulz/stitches/commit/a747c4a550e4091648ee52cb76ee1d2b27628c0a#diff-9731eac31947a9ee3816b17a76ad0badR275-R285)
- [`isComposedAtom`](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-9731eac31947a9ee3816b17a76ad0badR287-R292)

Noticed in [composeIntoMap](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-55646d75364ce42cdb84abec1a1531ccR426-R427) & [cssInstance](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-55646d75364ce42cdb84abec1a1531ccR623) that it can be a string. Is this correct as you end up with `atoms: (IAtom|string)[]` on a `IComposedAtom` instead of the defined [`atoms:IAtom[]`](https://github.com/modulz/stitches/blob/2b0a1e2e2ca413f1af96f166538809481c634351/packages/core/src/types.ts#L116) ? I've left it as is and added the typings that it can be a string and not just an `IAtom` passed around.


Ran into an issue with [cssInstance.keyframes](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-2991521f751aa9cf68976ceef512e19aR415) `IKeyframesAtom` usage in a couple of unit tests. As `cssInstance` [parameters](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-2991521f751aa9cf68976ceef512e19aR407) did not have the typings defined that an object with a `IKeyframesAtom` was being passed.

So added a couple `@ts-ignore` for now until someone can have a look at them to solve the issue.
- [should allow keyframes atom to be used as a direct object value](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-f212137c77c45e774722b9be132e9dc7R969-R970)
- [should inject styles for animations into sheet](https://github.com/modulz/stitches/compare/canary...andykenward:improve_ts?expand=1#diff-f212137c77c45e774722b9be132e9dc7R988-R989)

Cleaned up some `@ts-ignore` and `// tslint:disable-next-line`
