### PR TITLE
Add font method for creating font atoms

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -410,6 +410,7 @@ export interface TCss<T extends TConfig> {
     styles: string[];
     result: any;
   };
+  font: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => string;
   keyframes: (definition: Record<string, TFlatCSS<T> & TFlatUtils<T>>) => string;
   global: (definition: Record<string, TCssProperties<T>>) => () => string;
   theme: (

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1007,6 +1007,21 @@ describe('createCss: mixed(SSR & Client)', () => {
     `);
   });
 
+  test('should generate font atoms', () => {
+    const css = createCss({}, null);
+    const font = css.font({
+      fontWeight: 400,
+      fontDisplay: 'swap',
+      src:
+        "url(https://develop.modulz.app/fonts/UntitledSansWeb-Regular.woff2) format('woff2'), url(https://develop.modulz.app/fonts/UntitledSansWeb-Regular.woff) format('woff')",
+    });
+
+    expect(font._cssRuleString).toMatchInlineSnapshot(
+      `"@keyframes keYeiS {0% {background-color: red;}100% {background-color: green;}}"`
+    );
+    expect(font.toString()).toMatchInlineSnapshot(`"bbKwuh"`);
+  });
+
   test('should handle margin shorthand', () => {
     const css = createCss({}, null);
     const atom = css({ margin: '1px 5px' }) as any;


### PR DESCRIPTION
This change adds the CSS `@font-face` ability to stitches.

This change adds a `fonts` method to instances of `css`, allowing authors to create **font atoms** like [`keyframes`](https://stitches.dev/docs/api#csskeyframes).

### Example Usage

```js
const untitledSansRegular = css.font({
  fontWeight: 400,
  fontDisplay: 'swap',
  src: 'url("https://develop.modulz.app/fonts/UntitledSansWeb-Regular.woff2") format("woff2") url("https://develop.modulz.app/fonts/UntitledSansWeb-Regular.woff") format("woff")',
});

const Button = styled('button', {
  'fontFamily': untitledSansRegular
  }
});
```

### Additional Steps

- Let’s be sure we like the method name `font`. An alternative is `fontFace`.
- Let’s be sure this matches current expectations in stitches. A similar method for comparison is `keyframes`.
- Let’s be sure this feels intuitive to create fonts. There are 2 native expressions to consider. In CSS, font resources are declared with a `@font-face` at-rule whose identifier is declared inside the rule as a property. In Web APIs, font resources are declared with a [`new FontFace(family, source, descriptors)` constructors](https://developer.mozilla.org/en-US/docs/Web/API/FontFace/FontFace). 
- Let’s be sure this feels intuitive to assign fonts, e.g. `${untitledSansRegular}, sans-serif`.

Resolves #241