### PR TITLE
Restore defaultProps keeping the deprecation message

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -130,8 +130,10 @@ export interface IStyledComponent<
 
   /**
    * @deprecated
+   * React's defaultProps will be deprecated for Functional Components.
+   * Keep in mind this may stop working on a future release of `@stitches/react`
    */
-  defaultProps?: never;
+  defaultProps?: VariantASProps<Config, Variants> & { [k: string]: any };
 }
 /** Typed css with tokens and breakpoints */
 export type TCssWithBreakpoints<Config extends TConfig> = TCssProp<Config> &


### PR DESCRIPTION
Restore the typing for defaultProps because it was giving TypeScript errors, without removing the deprecation notice.

Issue reproduction:
- https://codesandbox.io/s/broken-architecture-ojw1w?file=/src/App.tsx:301-302
- Open [this file](https://github.com/modulz/stitches/blob/1e777795e6de1edc06a4502817745183bffea239/packages%2Freact%2Ftests%2Findex.test.tsx#L197) locally and TypeScript will complain﻿
