### PR TITLE
Fix textDecorationColor mapping

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -78,6 +78,7 @@ export const cssPropToToken: ICssPropToToken<any> = {
   outlineColor: 'colors',
   fill: 'colors',
   stroke: 'colors',
+  textDecorationColor: 'colors',
   fontFamily: 'fonts',
   fontWeight: 'fontWeights',
   lineHeight: 'lineHeights',

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -619,6 +619,7 @@ describe('createCss: mixed(SSR & Client)', () => {
       css({ marginTop: '1' }).toString();
       css({ gap: '2' }).toString();
       css({ outlineColor: 'red500' }).toString();
+      css({ textDecorationColor: 'red500' }).toString();
       return '';
     });
 
@@ -629,6 +630,7 @@ describe('createCss: mixed(SSR & Client)', () => {
         "/* STITCHES:__keyframes__ */
       ",
         "/* STITCHES */
+      ./*X*/_gIEnvj/*X*/{text-decoration-color:var(--colors-red500);}
       ./*X*/_bKAHZJ/*X*/{outline-color:var(--colors-red500);}
       ./*X*/_gTWOjC/*X*/{row-gap:var(--space-2);}
       ./*X*/_liLbrO/*X*/{column-gap:var(--space-2);}


### PR DESCRIPTION
Adds `textDecorationColor` token mapping reported by @colmtuite 