### PR TITLE
Add debugging className based on `showFriendlyClassnames` config

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -232,6 +232,13 @@ export const createStyled = <Config extends TConfig>(
 
     const stitchesComponentId = `scid-${hashString(JSON.stringify(baseAndVariantStyles))}`;
 
+    const componentDisplayName =
+      typeof currentAs === 'string'
+        ? `styled(${currentAs})`
+        : Component && Component.displayName
+        ? `styled(${Component.displayName})`
+        : `styled(Component\)`;
+
     const StitchesComponent = React.forwardRef((props: any, ref: React.Ref<Element>) => {
       const compositions = [baseStyles];
 
@@ -286,7 +293,12 @@ export const createStyled = <Config extends TConfig>(
 
       // By default we don't stringify the classname (composition), so that
       // the children Stitches component is responsible for the final composition
-      let className = css(stitchesComponentId, ...compositions, props.className);
+      let className = css(
+        stitchesComponentId,
+        ...compositions,
+        props.className,
+        config.showFriendlyClassnames ? componentDisplayName : undefined
+      );
 
       // If we're not wrapping a Stitches component,
       // we ensure the classname is stringified
@@ -305,12 +317,7 @@ export const createStyled = <Config extends TConfig>(
 
     (StitchesComponent as any).__isStitchesComponent = true;
 
-    StitchesComponent.displayName =
-      typeof currentAs === 'string'
-        ? `styled(${currentAs})`
-        : Component && Component.displayName
-        ? `styled(${Component.displayName})`
-        : `styled(Component\)`;
+    StitchesComponent.displayName = componentDisplayName;
 
     StitchesComponent.toString = () => `.${stitchesComponentId}`;
 

--- a/packages/react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`styled Breakpoints work in variants 1`] = `
     "._breakpointTwo_h_hiyRrM {height: 20px;}"
   ],
   "props": {
-    "className": "_initial_c_vfarC _breakpointOne_h_KwWJf _breakpointTwo_h_hiyRrM scid-kvQUME"
+    "className": "styled(button) _initial_c_vfarC _breakpointOne_h_KwWJf _breakpointTwo_h_hiyRrM scid-kvQUME"
   },
   "children": [
     "no variant"
@@ -24,7 +24,7 @@ exports[`styled Breakpoints work in variants and when a responsive variant is pa
     "._breakpointTwo_h_dPiPAc {height: 200px;}"
   ],
   "props": {
-    "className": "_breakpointOne_h_dDcWdv _breakpointTwo_h_dPiPAc _initial_c_vfarC scid-cXpAaU"
+    "className": "styled(button) _breakpointOne_h_dDcWdv _breakpointTwo_h_dPiPAc _initial_c_vfarC scid-cXpAaU"
   },
   "children": [
     "with responsive variant"
@@ -40,7 +40,7 @@ exports[`styled Breakpoints work in variants and when the variant is passed to t
     "._breakpointTwo_h_fptqfg {height: 2000px;}"
   ],
   "props": {
-    "className": "_breakpointOne_h_kgNeVv _breakpointTwo_h_fptqfg _initial_c_vfarC scid-cXpAaU"
+    "className": "styled(button) _breakpointOne_h_kgNeVv _breakpointTwo_h_fptqfg _initial_c_vfarC scid-cXpAaU"
   },
   "children": [
     "with variant"
@@ -169,11 +169,10 @@ exports[`styled handles boolean compound variant 1`] = `
 Array [
   {
   "orderedAppliedStyles": [
-    "._oRObr {font-weight: bold;}",
-    "._kXqcij {text-decoration-line: underline;}"
+    "._oRObr {font-weight: bold;}"
   ],
   "props": {
-    "className": "_kXqcij _oRObr scid-idZRwg"
+    "className": "_oRObr scid-idZRwg"
   },
   "children": [
     "bold, underline"
@@ -181,11 +180,10 @@ Array [
 },
   {
   "orderedAppliedStyles": [
-    "._ldesWJ {text-style: italic;}",
-    "._UNaLq {text-transform: uppercase;}"
+    "._ldesWJ {text-style: italic;}"
   ],
   "props": {
-    "className": "_UNaLq _ldesWJ scid-idZRwg"
+    "className": "_ldesWJ scid-idZRwg"
   },
   "children": [
     "italic, uppercase"

--- a/packages/react/tests/index.test.tsx
+++ b/packages/react/tests/index.test.tsx
@@ -360,4 +360,17 @@ describe('styled', () => {
     });
     expect(renderer.create(<Button size={0}>height should equal '1px'</Button>).toJSON()).toMatchSnapshot();
   });
+
+  test('It creates a debugging className with the component name', () => {
+    const { styled: _styled } = createStyled({
+      showFriendlyClassnames: true,
+    });
+
+    const Component = ({ className }: any) => {
+      expect(className).toContain('styled(Component)');
+      return <div>hello</div>;
+    };
+    const Button = _styled(Component, {});
+    renderer.create(<Button size={{ breakpointOne: 'small' }}>with responsive variant</Button>);
+  });
 });


### PR DESCRIPTION
I've been using Stitches in a personal project, and I've struggled to debug the HTML output and its classNames, as there is no way to know which HTML-tag represents my component, expects by React debug but I can't check out the CSS there. 

So in order to be able to recognize the component on the DOM tree, I've added the `displayName`, which is set in the `StitchesComponent` too, to the main `classNames` based on the `config.showFriendlyClassnames` values. 

Previous output:
```html
<div class="_initial_c_vfarC" />
``` 

Current output using `BodyWrapper` component as an example:
```html
<div class="styled(BodyWrapper) _initial_c_vfarC" />
```

The downside here is that this className is completely useless for styling purpose, but I guess that `showFriendlyClassnames`'s value must be conditional based in the current environment.

```js
const { styled, css } = createStyled({
  showFriendlyClassnames: process.env.NODE_ENV !== "production"
  ...
})
```

Side note: `showFriendlyClassnames` is missing in the documentation, if you don't have any objection about it, I can take care at this later.