### PR TITLE
Update react types

### DIFF
--- a/packages/core/tests/types.test.ts
+++ b/packages/core/tests/types.test.ts
@@ -1,6 +1,11 @@
 //core types.tests.ts
 import createCss, { StitchesCss, StitchesVariants } from '../types/index.d'
 const css = createCss({
+	utils: {
+		mx: (config) => (value) => ({
+			backgroundColor: 'red',
+		}),
+	},
 	theme: {
 		colors: {
 			hiContrast: 'hsl(200, 12%, 5%)',
@@ -70,7 +75,7 @@ const ExternalStyles: CSS = {
 
 const PotatoButton = css.css({
 	variants: {
-		variant: {
+		color: {
 			red: {},
 			blue: {},
 		},

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -99,6 +99,7 @@ export declare const $variants: unique symbol
 export declare const $conditions: unique symbol
 
 export type StitchesVariants<T> = T extends { [$variants]: infer V; [$conditions]: infer C } ? VariantsCall<V, C> : {}
+export type StitchesExtractVariantsStyles<T> = T extends { [$variants]: infer V } ? V : {}
 
 type StyledSheetCallback = (...cssText: string[]) => void
 
@@ -231,7 +232,7 @@ export type FlatInternalCSS<
 /* ========================================================================== */
 
 /** Combines rest parameter variants into one: */
-type InferRestVariants<Args extends any[]> = Args[0] & (HasTail<Args> extends true ? InferRestVariants<Tail<Args>> : {})
+export type InferRestVariants<Args extends any[]> = Args[0] & (HasTail<Args> extends true ? InferRestVariants<Tail<Args>> : {})
 
 /* Check if current array has a tail: */
 type HasTail<T extends any[]> = T extends [] | [any] ? false : true
@@ -320,10 +321,11 @@ export interface TStyledSheet<A extends TConditions = {}, B extends TTheme = {},
 	/** Prefix applied to all styled and themed rules. */
 	prefix: string
 }
-type CastNumberToString<T> = T extends number ? `${T}` | T : T
+type MorphVariants<T> = T extends number ? `${T}` | T : T extends "true" ? "true" | true : T extends "false" ? "false" | false : T
+
 
 export type VariantsCall<Variants, Conditions> = {
-	[k in keyof Variants]?: CastNumberToString<keyof Variants[k]> | { [I in keyof Conditions]?: CastNumberToString<keyof Variants[k]> }
+	[k in keyof Variants]?: MorphVariants<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariants<keyof Variants[k]> }
 }
 
 /** Extracts the css type from the  */

--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
-import createStyled, { StitchesVariants } from '../types/index.d'
+import createStyled from '../types/index.d'
 
 const { styled } = createStyled({
+	theme: {
+		colors: {},
+	},
 	conditions: {
 		large: '',
 	},
@@ -9,6 +12,10 @@ const { styled } = createStyled({
 
 const Button = styled('button', {
 	variants: {
+		isDisabled: {
+			true: {},
+			false: {},
+		},
 		variant: {
 			red: {
 				backgroundOrigin: '',
@@ -17,19 +24,26 @@ const Button = styled('button', {
 	},
 })
 
-/** TODO: Fix extending stitches components */
-const ExtendedButton = styled('button', {
+const ExtendedButton = styled(Button, {
 	variants: {
 		variant: {
-			red: {},
-		},
-		size: {
-			large: {},
+			blue: {
+				color: 'ActiveBorder',
+				backgroundColor: 'ActiveCaption',
+			},
 		},
 	},
 })
 
-type Variants = StitchesVariants<typeof ExtendedButton>
+const ReactComponent: React.FC = (props) => <div></div>
+
+const StitchesExtendingReactComponent = styled(ReactComponent, {
+	backgroundColor: 'red',
+	backgroundOrigin: 'border-box',
+	backdropFilter: 'inherit',
+})
+
+type Props = React.ComponentProps<typeof StitchesExtendingReactComponent>
 
 /* -------------------------------------------------------------------------------------------------
  * Extended Button using react utilities without polymorphism
@@ -82,16 +96,16 @@ export function Test() {
 
 			{/* Button does not accept href prop */}
 			{/* @ts-expect-error */}
-			<Button href="" />
+			<Button as="div" href="" />
 
-			{/* Button accepts form prop */}
+			{/* Button accepts form  prop */}
 			<Button form="form" onClick={(e) => {}} />
 
 			{/* Button accepts css prop */}
 			<Button css={{ backgroundColor: 'ActiveCaption', padding: 'inherit' }} />
 
 			{/* Button accepts isDisabled prop */}
-			<Button variant="red" />
+			<Button isDisabled />
 
 			{/* Button accepts a responsive variant */}
 			<Button variant={{ large: 'red' }} />
@@ -120,7 +134,7 @@ export function Test() {
 			<Button onClick={(event) => event.currentTarget.form} />
 
 			{/* Button as "a" accepts onClick prop */}
-			<Button as="a" onClick={(event) => event.currentTarget.href} />
+			<Button as="svg" onClick={(event) => event.currentTarget} css={{ backgroundColor: 'ActiveBorder' }} />
 
 			{/* Button as Link accepts onClick prop, but it must be explicitly typed */}
 			<Button as={Link} onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => event.altKey} />
@@ -128,8 +142,8 @@ export function Test() {
 			{/* ExtendedButton accepts variant prop */}
 			<ExtendedButton variant="red" />
 
-			{/* ExtendedButton accepts size prop */}
-			<ExtendedButton size="large" />
+			{/* ExtendedButton accepts isDisabled prop */}
+			<ExtendedButton isDisabled />
 
 			{/* ExtendedButton is typed as a button */}
 			<ExtendedButton
@@ -155,6 +169,18 @@ export function Test() {
 			{/* ExtendedButtonUsingReactUtils does not accept as prop */}
 			{/* @ts-expect-error */}
 			<ExtendedButtonUsingReactUtils as="a" isDisabled />
+
+			{/** As works on extended element */}
+			<StitchesExtendingReactComponent
+				as="a"
+				href="fwef"
+				onClick={(e) => {
+					console.log(e)
+				}}
+			/>
+			{/** As errors on extended element when passed a wrong prop */}
+			{/* @ts-expect-error */}
+			<StitchesExtendingReactComponent href="fwef" />
 		</>
 	)
 }

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -34,7 +34,7 @@ export interface StitchesComponent<DefaultElement, Variants = {}, Conditions = {
 	<M extends string>(props: NativeStitchesPropsWithAs<M, Variants, Conditions, Theme, Utils>): JSX.Element
 	<As extends React.ComponentType>(props: StitchesPropsWithAs<As, Variants, Conditions, Theme, Utils>): JSX.Element
 	(
-		props: VariantsCall<Variants, Conditions> & { as?: DefaultElement } & React.ComponentPropsWithRef<ComponentInfer<DefaultElement>> & {
+		props: VariantsCall<Variants, Conditions> & { as?: DefaultElement } & Omit<React.ComponentPropsWithRef<ComponentInfer<DefaultElement>>, keyof Variants | 'css' | 'as'> & {
 				css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 			},
 	): JSX.Element
@@ -42,19 +42,15 @@ export interface StitchesComponent<DefaultElement, Variants = {}, Conditions = {
 	[$conditions]: Conditions
 }
 
-export type StitchesProps<Elm extends React.ElementType, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> &
-	Omit<React.ComponentPropsWithRef<Elm>, keyof Variants | 'css'> & {
-		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
-	}
 type NativeStitchesPropsWithAs<Elm extends string, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> & { as: Elm } & Omit<
 		JSX.IntrinsicElements[Elm extends IntrinsicElementsKeys ? Elm : never],
-		keyof Variants | 'css'
+		keyof Variants | 'css' | 'as'
 	> & {
 		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 	}
 type StitchesPropsWithAs<Elm extends React.ElementType, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> & { as: Elm } & Omit<
 		React.ComponentPropsWithRef<Elm>,
-		keyof Variants | 'css'
+		keyof Variants | 'css' | 'as'
 	> & {
 		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 	}

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,7 +1,17 @@
 import * as React from 'react'
-import { InternalCSS, TConditions, TTheme, TStyledSheet, VariantsCall, IConfig, TThemeMap, CSSPropertiesToTokenScale, $variants, $conditions, StitchesVariants } from '@stitches/core'
+import { InternalCSS, TConditions, TTheme, TStyledSheet, VariantsCall, IConfig, TThemeMap, CSSPropertiesToTokenScale, $variants, $conditions, StitchesExtractVariantsStyles, InferRestVariants } from '@stitches/core'
 
-export type { StitchesVariants, StitchesCss } from '@stitches/core'
+export type { StitchesVariants, StitchesCss, StitchesExtractVariantsStyles } from '@stitches/core'
+
+export interface PolymorphicForwardRef<DefaultElement, Props> extends ForwardRefExoticBase<IntrinsicElementPolymorphicPropsWithAs<DefaultElement, Props>> {
+	<JSXElm extends string>(props: IntrinsicElementPolymorphicPropsWithAs<JSXElm, Props>): JSX.Element
+	<Component extends React.ComponentType>(props: ReactComponentPolymorphicPropsWithAs<Component, Props>): JSX.Element
+	(props: IntrinsicElementPolymorphicPropsWithAs<DefaultElement, Props>): JSX.Element
+}
+
+type IntrinsicElementPolymorphicPropsWithAs<Elm, Props> = { as: Elm } & Omit<JSX.IntrinsicElements[Elm extends keyof JSX.IntrinsicElements ? Elm : never], keyof Props> & Props
+type ReactComponentPolymorphicPropsWithAs<Elm, Props> = { as: Elm } & Omit<React.ComponentPropsWithRef<Elm extends React.ComponentType ? Elm : never>, keyof Props> & Props
+
 /* Utils:
  * -----------------------------------------------------------------------------------------------*/
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
@@ -13,48 +23,41 @@ type ComponentInfer<T> = T extends IntrinsicElementsKeys | React.ComponentType<a
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
 type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>
 
-export interface StitchesComponent<DefaultElement extends React.ElementType, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}>
+export type IntrinsicElement<T extends React.ElementType, B = React.ElementRef<T>> = { [k in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[k] extends B ? k : never }[keyof HTMLElementTagNameMap]
+
+export interface StitchesComponent<DefaultElement, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}>
 	extends ForwardRefExoticBase<
-		Omit<React.ComponentPropsWithRef<DefaultElement>, keyof Variants | 'css' | 'as'> & {
+		Omit<React.ComponentPropsWithRef<ComponentInfer<DefaultElement>>, keyof Variants | 'css' | 'as'> & {
 			css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 		} & VariantsCall<Variants, Conditions>
 	> {
-	[$variants]: Variants
-	[$conditions]: Conditions
-	/** TODO: Decide which and how many elements we want to give their own overload */
-	(props: StitchesPropsWithAs<'div', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'code', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'pre', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'span', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'a', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'p', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'li', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'ul', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'image', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'table', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'td', Variants, Conditions, Theme, Utils>): JSX.Element
-	(props: StitchesPropsWithAs<'tr', Variants, Conditions, Theme, Utils>): JSX.Element
+	<M extends string>(props: NativeStitchesPropsWithAs<M, Variants, Conditions, Theme, Utils>): JSX.Element
 	<As extends React.ComponentType>(props: StitchesPropsWithAs<As, Variants, Conditions, Theme, Utils>): JSX.Element
 	(
-		props: VariantsCall<Variants, Conditions> & { as?: DefaultElement } & React.ComponentPropsWithRef<DefaultElement> & {
+		props: VariantsCall<Variants, Conditions> & { as?: DefaultElement } & React.ComponentPropsWithRef<ComponentInfer<DefaultElement>> & {
 				css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 			},
 	): JSX.Element
+	[$variants]: Variants
+	[$conditions]: Conditions
 }
 
 export type StitchesProps<Elm extends React.ElementType, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> &
 	Omit<React.ComponentPropsWithRef<Elm>, keyof Variants | 'css'> & {
 		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 	}
-
+type NativeStitchesPropsWithAs<Elm extends string, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> & { as: Elm } & Omit<
+		JSX.IntrinsicElements[Elm extends IntrinsicElementsKeys ? Elm : never],
+		keyof Variants | 'css'
+	> & {
+		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
+	}
 type StitchesPropsWithAs<Elm extends React.ElementType, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}> = VariantsCall<Variants, Conditions> & { as: Elm } & Omit<
 		React.ComponentPropsWithRef<Elm>,
 		keyof Variants | 'css'
 	> & {
 		css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
 	}
-
-export type IntrinsicElement<T extends React.ElementType, B = React.ElementRef<T>> = { [k in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[k] extends B ? k : never }[keyof HTMLElementTagNameMap]
 
 // export type NonIntrinsicElementProps<T extends React.ElementType> = IntrinsicElement<T> extends never ? React.ComponentProps<T> : Omit<React.ComponentProps<T>, keyof React.ComponentPropsWithoutRef<IntrinsicElement<T>>>
 
@@ -66,7 +69,7 @@ export type StyledInstance<Conditions = {}, Theme extends TTheme = {}, Utils = {
 		styles: InternalCSS<Conditions, Theme, Utils, ThemeMap> & {
 			variants?: { [k in keyof Variants]: { [b in keyof Variants[k]]: InternalCSS<Conditions, Theme, Utils, ThemeMap> } }
 		},
-	): StitchesComponent<E, Variants & StitchesVariants<E>, Conditions, Theme, Utils>
+	): StitchesComponent<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils>
 }
 
 type ReactFactory = <Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap extends TThemeMap = CSSPropertiesToTokenScale>(


### PR DESCRIPTION
- Fixes polymorphic types
- Fixes losing variants after extending stitches components 
- Fixed type boolean casting variant names to strings (@jonathantneal FYI, had to create a new type for it in core)
- Fixed variants props erroring when the element also has a variant with the same name

@jonathantneal I noticed that you've created a new CSS type `LessInternalCSS` to fix the CSS props as variants but I didn't start using it as I saw that it had a todo above it. let me know if it's safe to use so that I update the react package to use this fixed type.

@peduarte in the react package, there is a `types.tests.tsx` file in the tests folder which has a bunch of ts tests for the polymorphic stuff that you could use during testing. 
Please use it for your testing and if you find any bugs, please push them to this branch