### PR TITLE
export all the types

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -101,19 +101,19 @@ export declare const $conditions: unique symbol
 export type StitchesVariants<T> = T extends { [$variants]: infer V; [$conditions]: infer C } ? VariantsCall<V, C> : {}
 export type StitchesExtractVariantsStyles<T> = T extends { [$variants]: infer V } ? V : {}
 
-type StyledSheetCallback = (...cssText: string[]) => void
+export type StyledSheetCallback = (...cssText: string[]) => void
 
-interface GlobalRule {
+export interface GlobalRule {
 	(): void
 }
 
-interface ThemeRule {
+export interface ThemeRule {
 	toString(): string
 	className: string
 	cssText: string
 	root: string
 }
-interface StyledExpression {
+export interface StyledExpression {
 	(): string
 	toString(): string
 	className: string
@@ -128,7 +128,7 @@ interface StyledExpression {
 // Just used as a keyof target for the config
 // for some weird reason, autocomplete stops working
 // if we try to pre compute the keys or use a union
-type EmptyTheme = {
+export type EmptyTheme = {
 	colors?: {}
 	space?: {}
 	fontSizes?: {}
@@ -169,7 +169,7 @@ export interface IConfig<Conditions extends TConditions = {}, Theme extends TThe
 	onThemed?: StyledSheetCallback
 }
 
-interface InternalConfig<Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap = {}> {
+export interface InternalConfig<Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap = {}> {
 	conditions: Conditions
 	theme: Theme
 	utils: {
@@ -179,7 +179,7 @@ interface InternalConfig<Conditions extends TConditions = {}, Theme extends TThe
 	prefix: Prefix
 }
 
-type MapUtils<T> = { [k in keyof T]: T[k] extends (theme: any) => (value: infer V) => any ? V : never }
+export type MapUtils<T> = { [k in keyof T]: T[k] extends (theme: any) => (value: infer V) => any ? V : never }
 
 /* Css typed structure:
 /* ========================================================================== */
@@ -351,7 +351,7 @@ export type StitchesCss<T> = T extends { config: { conditions: infer Conditions;
 
 /* Output Styled Rule:
 /* ========================================================================== */
-interface IStyledRule<Variants, Conditions, Theme, Utils, ThemeMap> {
+export interface IStyledRule<Variants, Conditions, Theme, Utils, ThemeMap> {
 	//
 	(
 		init?: VariantsCall<Variants, Conditions> & {

--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -1,40 +1,40 @@
 import * as React from 'react'
 import createStyled, { StitchesCss } from '../types/index.d'
-const theme = {
-	colors: {
-		hiContrast: 'hsl(200, 12%, 5%)',
-		loContrast: 'white',
 
-		gray100: 'hsl(206, 20%, 98.8%)',
-		gray200: 'hsl(206, 14%, 96.0%)',
-		gray300: 'hsl(206, 13%, 93.7%)',
-		gray400: 'hsl(206, 12%, 92.0%)',
-		gray500: 'hsl(206, 12%, 89.5%)',
-		gray600: 'hsl(206, 11%, 85.2%)',
-		gray700: 'hsl(206, 10%, 80.0%)',
-		gray800: 'hsl(206, 6%, 56.1%)',
-		gray900: 'hsl(206, 6%, 43.9%)',
-
-		pedro: '$gray100',
-	},
-	space: {
-		1: '10px',
-		2: '20px',
-	},
-	fontSizes: {
-		1: '11px',
-		2: '13px',
-		3: '15px',
-		4: '17px',
-		5: '19px',
-		6: '21px',
-		7: '27px',
-		8: '35px',
-		9: '59px',
-	},
-}
 const factory = createStyled({
-	theme,
+	theme: {
+		colors: {
+			hiContrast: 'hsl(200, 12%, 5%)',
+			loContrast: 'white',
+
+			gray100: 'hsl(206, 20%, 98.8%)',
+			gray200: 'hsl(206, 14%, 96.0%)',
+			gray300: 'hsl(206, 13%, 93.7%)',
+			gray400: 'hsl(206, 12%, 92.0%)',
+			gray500: 'hsl(206, 12%, 89.5%)',
+			gray600: 'hsl(206, 11%, 85.2%)',
+			gray700: 'hsl(206, 10%, 80.0%)',
+			gray800: 'hsl(206, 6%, 56.1%)',
+			gray900: 'hsl(206, 6%, 43.9%)',
+
+			pedro: '$gray100',
+		},
+		space: {
+			1: '10px',
+			2: '20px',
+		},
+		fontSizes: {
+			1: '11px',
+			2: '13px',
+			3: '15px',
+			4: '17px',
+			5: '19px',
+			6: '21px',
+			7: '27px',
+			8: '35px',
+			9: '59px',
+		},
+	},
 	conditions: {
 		bp1: '@media (min-width: 620px)',
 	},
@@ -48,8 +48,8 @@ const factory = createStyled({
 
 type CSS = StitchesCss<typeof factory>
 
-const { styled } = factory
-
+export const { styled, toString, theme, css, keyframes, global } = factory
+const themeClass = theme('dark', {})
 const sharedColor: CSS = {
 	backgroundColor: 'red',
 	fwefwe: {

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { InternalCSS, LessInternalCSS, TConditions, TTheme, TStyledSheet, VariantsCall, IConfig, TThemeMap, CSSPropertiesToTokenScale, $variants, $conditions, StitchesExtractVariantsStyles } from '@stitches/core'
 
-export type { StitchesVariants, StitchesCss, StitchesExtractVariantsStyles } from '@stitches/core'
+export * from '@stitches/core'
 
 export interface PolymorphicForwardRef<DefaultElement, Props> extends ForwardRefExoticBase<IntrinsicElementPolymorphicPropsWithAs<DefaultElement, Props>> {
 	<JSXElm extends string>(props: IntrinsicElementPolymorphicPropsWithAs<JSXElm, Props>): JSX.Element


### PR DESCRIPTION
@jonathantneal nothing in here just exporting the types so that typescript is able to compile them correctly when destructuring 