### PR TITLE
Fix: Support looser morph variants

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -398,7 +398,7 @@ export interface TStyledSheet<A extends TConditions = {}, B extends TTheme = {},
 	/** Prefix applied to all styled and themed rules. */
 	prefix: string
 }
-type MorphVariants<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | true : T extends 'false' ? 'false' | false : T
+type MorphVariants<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T
 
 export type VariantsCall<Variants, Conditions> = {
 	[k in keyof Variants]?: MorphVariants<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariants<keyof Variants[k]> }


### PR DESCRIPTION
This PR changes morph variant typing to support boolean values, which are naturally typed as a kind of union of `true` and `false`.

### Background

When an author creates variants with values of `true` or `false`, they actually exist as string values `"true"` or `"false"`. Currently, we support their targeting them with literal boolean values using _morph variants_.

However an author creates a variant with only one boolean value, then TypeScript would only allow that literal boolean value. However, since boolean values are naturally a kind of union of `true` or `false`, this causes TypeScript to flag the perfectly valid boolean value.