### PR TITLE
feat: always add css on reference, implicitly return className on theme

### DIFF
--- a/packages/core/src/Object.js
+++ b/packages/core/src/Object.js
@@ -1,3 +1,5 @@
 export default Object
 
-export const { assign, create } = Object
+export const { assign, create, defineProperties, getOwnPropertyDescriptors } = Object
+
+export const define = (target, append) => defineProperties(target, getOwnPropertyDescriptors(append))

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -37,15 +37,6 @@ export default (init) => {
 	)
 
 	const sheet = createCoreCss(init)
-	const { theme } = sheet
-
-	function toString() {
-		return this.render().selector
-	}
-
-	function toCallString() {
-		return this().selector
-	}
 
 	return assign(sheet, {
 		sync() {
@@ -55,11 +46,6 @@ export default (init) => {
 				if (!sheetTarget.parentNode) sheetParent.prepend(sheetTarget)
 			}
 		},
-		theme: (...args) =>
-			assign(theme(...args), {
-				[Symbol.toPrimitive]: toCallString,
-				toString: toCallString,
-			}),
 		styled: new Proxy(
 			/** Returns a React component. */
 			(
@@ -74,9 +60,6 @@ export default (init) => {
 				/** Returns a React element. */
 				return Object.setPrototypeOf(
 					{
-						...expression,
-						[Symbol.toPrimitive]: toString,
-						toString,
 						$$typeof: $$typeofForward,
 						render(
 							/** Props used to determine the expression of the current component. */
@@ -95,6 +78,20 @@ export default (init) => {
 							/** React element. */
 							return { ...expressedProps, constructor: undefined, $$typeof, props, ref, type, __v: 0 }
 						},
+						[Symbol.toPrimitive]() {
+							return expression.selector
+						},
+						toString() {
+							return expression.selector
+						},
+						get className() {
+							return expression.className
+						},
+						get selector() {
+							return expression.selector
+						},
+						classNames: expression.classNames,
+						variants: expression.variants,
 					},
 					Object(asType),
 				)

--- a/packages/react/tests/serialization.js
+++ b/packages/react/tests/serialization.js
@@ -17,7 +17,8 @@ describe('Serialization', () => {
 			blue: 'dodgerblue',
 		},
 	})
-	const myThemeSelector = '.sx7guyg'
+	const myThemeClass = 'sx7guyg'
+	const myThemeSelector = `.${myThemeClass}`
 
 	test('Components implicitly return their selector', () => {
 		expect(String(myComponent)).toBe(myComponentSelector)
@@ -25,20 +26,24 @@ describe('Serialization', () => {
 		expect(`${myComponent}`).toBe(myComponentSelector)
 	})
 
-	test('Themes implicitly return their selector', () => {
-		expect(String(myTheme)).toBe(myThemeSelector)
-		expect('' + myTheme).toBe(myThemeSelector)
-		expect(`${myTheme}`).toBe(myThemeSelector)
-	})
-
 	test('Components can explicitly return their selector', () => {
 		expect(myComponent.selector).toBe(myComponentSelector)
 		expect(myComponent.toString()).toBe(myComponentSelector)
 	})
 
+	test('Themes implicitly return their className', () => {
+		expect(String(myTheme)).toBe(myThemeClass)
+		expect('' + myTheme).toBe(myThemeClass)
+		expect(`${myTheme}`).toBe(myThemeClass)
+	})
+
+	test('Themes can explicitly return their className', () => {
+		expect(myTheme.className).toBe(myThemeClass)
+		expect(myTheme.toString()).toBe(myThemeClass)
+	})
+
 	test('Themes can explicitly return their selector', () => {
 		expect(myTheme.selector).toBe(myThemeSelector)
-		expect(myTheme.toString()).toBe(myThemeSelector)
 	})
 
 	const sheetCssText = `${myThemeSelector}{--colors-blue:dodgerblue;}${myComponentSelector}{all:unset;font:inherit;margin:0;padding:0.5em 1em;}`


### PR DESCRIPTION
This PR updates both the core and react releases to add css on reference, so that referencing a theme like `className={theme}` would automatically push the theme CSS into the stylesheet. This PR also rolls back a change to `theme()`, which started returning a selector, but will now return a class name as it did before.