### PR TITLE
Feature: Add a named createCss export

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -8,7 +8,7 @@ import getCustomProperties from './getCustomProperties.js'
 import getHashString from './getHashString.js'
 
 /** Returns a new styled sheet and accompanying API. */
-export default (init) => {
+const createCss = (init) => {
 	init = Object(init)
 
 	const config = {
@@ -363,4 +363,4 @@ export default (init) => {
 	}
 }
 
-export { defaultThemeMap }
+export { createCss as default, createCss, defaultThemeMap }

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -457,4 +457,5 @@ type TStyledSheetFactory = <Conditions extends TConditions = {}, Theme extends T
 ) => TStyledSheet<Conditions & { initial: '' }, Theme, Utils, Prefix, ThemeMap>
 
 declare const styled: TStyledSheetFactory
-export default styled
+
+export { styled as default, styled as createCss }

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -5,7 +5,7 @@ import defaultThemeMap from '../../core/src/defaultThemeMap.js'
 const $$typeof = Symbol.for('react.element')
 const $$typeofForward = Symbol.for('react.forward_ref')
 
-export default (init) => {
+const createCss = (init) => {
 	const hasDocument = typeof document === 'object'
 
 	const importText = hasDocument && new Text('')
@@ -103,4 +103,4 @@ export default (init) => {
 	}).reset()
 }
 
-export { defaultThemeMap }
+export { createCss as default, createCss, defaultThemeMap }

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -126,7 +126,7 @@ export type StyledInstance<Conditions = {}, Theme extends TTheme = {}, Utils = {
 					& {
 						compoundVariants?: (
 							{
-								[k in keyof CloneVariants]?: keyof CloneVariants[k] 
+								[k in keyof CloneVariants]?: keyof CloneVariants[k]
 							}
 							& {
 								css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>
@@ -167,4 +167,4 @@ type ReactFactory = <Conditions extends TConditions = {}, Theme extends TTheme =
 
 declare const styled: ReactFactory
 
-export default styled
+export { styled as default, styled as createCss }


### PR DESCRIPTION
This PR changes the exports of `@stitches/core` and `@stitches/react` so that the `createCss` default export is also a named export.

Examples:

```js
import { createCss } from '@stitches/core'
```

```js
import { createCss } from '@stitches/react'
```