### PR TITLE
fix: preserve props for variants named "as"

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -280,7 +280,7 @@ const createCss = (init) => {
 					const propValue = props[propName]
 					const variant = variants[propName]
 
-					delete props[propName]
+					if (propName !== 'as') delete props[propName]
 
 					// apply any matching variant
 					if (propValue in variant) {

--- a/packages/core/tests/as-prop.js
+++ b/packages/core/tests/as-prop.js
@@ -1,0 +1,27 @@
+import createCss from '../src/index.js'
+
+describe('As prop', () => {
+	test('The "as" property is passed through', () => {
+		const { css, toString } = createCss({})
+		const component = css({
+			variants: {
+				as: {
+					button: {
+						color: 'dodgerblue',
+					},
+					a: {
+						color: 'tomato',
+					},
+				},
+			},
+		})
+
+		expect(component({ as: 'button' }).className).toBe(['sx03kze', 'sx03kzer9r9e--as-button'].join(' '))
+		expect(component({ as: 'button' }).props.as).toBe('button')
+		expect(toString()).toBe(['.sx03kzer9r9e--as-button{color:dodgerblue;}'].join(''))
+
+		expect(component({ as: 'a' }).className).toBe(['sx03kze', 'sx03kzea4ldn--as-a'].join(' '))
+		expect(component({ as: 'a' }).props.as).toBe('a')
+		expect(toString()).toBe(['.sx03kzer9r9e--as-button{color:dodgerblue;}', '.sx03kzea4ldn--as-a{color:tomato;}'].join(''))
+	})
+})


### PR DESCRIPTION
This PR changes how variant props do not fall through, so that `as` does.