### PR TITLE
fix: correct how the react peerDependency should be written

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nodemon": "2.0.7",
     "npm-run-all": "4.1.5",
     "prettier": "^2.2.1",
+    "react": "^17.0.1",
     "react-test-renderer": "17.0.1",
     "terser": "5.5.1",
     "typescript": "4.1.4"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "react": "17.0.1"
   },
   "peerDependencies": {
-    "react": "17-18"
+    "react": ">=17.0.0 <19.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR changes the `package.json` of `@stitches/react` to reference a clearer range of supported React versions. This also adds `react` as a development dependency of the project.