### PR TITLE
Fix type inferred from the creator function in `@stitches/react`

### DIFF
--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -139,7 +139,7 @@ export type StyledInstance<Conditions = {}, Theme extends TTheme = {}, Utils = {
 
 type ReactFactory = <Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap extends TThemeMap = CSSPropertiesToTokenScale>(
 	_config?: IConfig<Conditions, Theme, Utils, Prefix, ThemeMap>,
-) => TStyledSheet<Conditions, Theme, Utils> & {
+) => TStyledSheet<Conditions, Theme, Utils, Prefix, ThemeMap> & {
 	styled: StyledInstance<Conditions & { initial: '' }, Theme, Utils, ThemeMap>
 
 	/**


### PR DESCRIPTION
This PR fixes type inference in the factory function of`@stitches/react` by adding several missing type arguments.

Fixes https://github.com/modulz/stitches/issues/366.