### PR TITLE
Remove unused types in `css-types.ts`

### DIFF
--- a/packages/core/types/css-types.ts
+++ b/packages/core/types/css-types.ts
@@ -7670,12 +7670,6 @@ export type TextAnchorProperty = Globals | 'end' | 'middle' | 'start'
 
 export type VectorEffectProperty = Globals | 'non-scaling-stroke' | 'none'
 
-type CounterStyleRangeProperty = 'auto' | 'infinite' | (string & {}) | number
-
-type CounterStyleSpeakAsProperty = 'auto' | 'bullets' | 'numbers' | 'spell-out' | 'words' | (string & {})
-
-type CounterStyleSystemProperty = 'additive' | 'alphabetic' | 'cyclic' | 'fixed' | 'numeric' | 'symbolic' | (string & {})
-
 type FontFaceFontFeatureSettingsProperty = 'normal' | (string & {})
 
 type FontFaceFontDisplayProperty = 'auto' | 'block' | 'fallback' | 'optional' | 'swap'


### PR DESCRIPTION
This PR removes unused CSS property types. Unused types are problematic because they cause type-checking to fail if you have the `noUnusedLocals` flag enabled in your `tsconfig.json`.

I also looked at https://github.com/frenic/csstype for reference and these types don't seem to be present there anymore either.