### PR TITLE
fix: issue where variants apply regardless

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -19,7 +19,7 @@ const createCss = (init) => {
 		theme: Object(init.theme),
 
 		/** Properties corresponding to functions that take in CSS values and return aliased CSS declarations. */
-		utils: Object(init.utils),
+		utils: assign(create(null), init.utils),
 	}
 
 	/** Prefix added before all generated class names. */
@@ -246,7 +246,6 @@ const createCss = (init) => {
 				const { css: compoundStyle, ...compounders } = Object(compound)
 
 				let appliedCompoundStyle = compoundStyle
-				let appliedConditions = new Set()
 
 				if (
 					Object.keys(compounders).every((name) => {

--- a/packages/core/tests/variants.js
+++ b/packages/core/tests/variants.js
@@ -1,13 +1,7 @@
 import createCss from '../src/index.js'
 
 describe('Variants', () => {
-	let component_1, component_2, component_3, component_4, component_5
-	let stylerule_1, stylerule_2, stylerule_3, stylerule_4, stylerule_5
-
-	const { css, toString } = createCss()
-
-	/** Component with variants and compound variants */
-	const COMPONENT = css({
+	const componentConfig = {
 		variants: {
 			color: {
 				blue: {
@@ -45,55 +39,64 @@ describe('Variants', () => {
 				},
 			},
 		],
-	})
+	}
 
 	test('Renders a component without any initial styles', () => {
-		component_1 = COMPONENT()
-		stylerule_1 = ''
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component()
 
-		expect(component_1.className).toBe('sx03kze')
-		expect(toString()).toBe(stylerule_1)
+		expect(expression.className).toBe('sx03kze')
+		expect(toString()).toBe('')
 	})
 
 	test('Renders a component with 1 matching variant', () => {
-		component_2 = COMPONENT({ size: 'small' })
-		stylerule_2 = stylerule_1 + '.sx03kzetmy8g--size-small{font-size:16px;}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression1 = component({ size: 'small' })
 
-		expect(component_2.className).toBe('sx03kze sx03kzetmy8g--size-small')
-		expect(toString()).toBe(stylerule_2)
+		const expression1CssText = '.sx03kzetmy8g--size-small{font-size:16px;}'
 
-		component_3 = COMPONENT({ color: 'blue' })
-		stylerule_3 = stylerule_2 + '.sx03kze4wpam--color-blue{background-color:dodgerblue;color:white;}'
+		expect(expression1.className).toBe('sx03kze sx03kzetmy8g--size-small')
+		expect(toString()).toBe(expression1CssText)
 
-		expect(component_3.className).toBe('sx03kze sx03kze4wpam--color-blue')
-		expect(toString()).toBe(stylerule_3)
+		const expression2 = component({ color: 'blue' })
+
+		const expression2CssText = '.sx03kze4wpam--color-blue{background-color:dodgerblue;color:white;}'
+
+		expect(expression2.className).toBe('sx03kze sx03kze4wpam--color-blue')
+		expect(toString()).toBe(expression1CssText + expression2CssText)
 	})
 
 	test('Renders a component with 2 matching variants', () => {
-		component_4 = COMPONENT({ size: 'small', level: 1 })
-		stylerule_4 = stylerule_3 + '.sx03kzehmqox--level-1{padding:0.5em;}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ size: 'small', level: 1 })
 
-		expect(component_4.className).toBe('sx03kze sx03kzetmy8g--size-small sx03kzehmqox--level-1')
-		expect(toString()).toBe(stylerule_4)
+		expect(expression.className).toBe('sx03kze sx03kzetmy8g--size-small sx03kzehmqox--level-1')
+
+		const expressionSizeSmallCssText = '.sx03kzetmy8g--size-small{font-size:16px;}'
+		const expressionLevel1CssText = '.sx03kzehmqox--level-1{padding:0.5em;}'
+
+		expect(toString()).toBe(expressionSizeSmallCssText + expressionLevel1CssText)
 	})
 
 	test('Renders a component with a 2 matching variants and 1 matching compound', () => {
-		component_5 = COMPONENT({ size: 'small', color: 'blue' })
-		stylerule_5 = stylerule_4 + '.sx03kzeif1wl--comp{transform:scale(1.2);}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ size: 'small', color: 'blue' })
 
-		expect(component_5.className).toBe('sx03kze sx03kzeif1wl--comp sx03kzetmy8g--size-small sx03kze4wpam--color-blue')
-		expect(toString()).toBe(stylerule_5)
+		const expressionSizeSmallCssText = '.sx03kzetmy8g--size-small{font-size:16px;}'
+		const expressionColorBlueCssText = '.sx03kze4wpam--color-blue{background-color:dodgerblue;color:white;}'
+		const expressionCompoundCssText = '.sx03kzeif1wl--comp{transform:scale(1.2);}'
+
+		expect(expression.className).toBe('sx03kze sx03kzeif1wl--comp sx03kzetmy8g--size-small sx03kze4wpam--color-blue')
+		expect(toString()).toBe(expressionSizeSmallCssText + expressionColorBlueCssText + expressionCompoundCssText)
 	})
 })
 
 describe('Variants with defaults', () => {
-	let component_1, component_2, component_3, component_4, component_5
-	let stylerule_1, stylerule_2, stylerule_3, stylerule_4, stylerule_5
-
-	const STITCHES = createCss()
-
-	/** Component with variants and compound variants */
-	const component = STITCHES.css({
+	const componentConfig = {
 		variants: {
 			color: {
 				blue: {
@@ -134,54 +137,67 @@ describe('Variants with defaults', () => {
 		defaultVariants: {
 			size: 'small',
 		},
-	})
+	}
 
 	test('Renders a component with the default variant applied', () => {
-		component_1 = component()
-		stylerule_1 = '.sx03kzetmy8g--size-small{font-size:16px;}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component()
 
-		expect(component_1.className).toBe('sx03kze sx03kzetmy8g--size-small')
-		expect(STITCHES.toString()).toBe(stylerule_1)
+		expect(expression.className).toBe('sx03kze sx03kzetmy8g--size-small')
+		expect(toString()).toBe('.sx03kzetmy8g--size-small{font-size:16px;}')
 	})
 
 	test('Renders a component with the default variant explicitly applied', () => {
-		component_2 = component({ size: 'small' })
-		stylerule_2 = stylerule_1 + ''
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ size: 'small' })
 
-		expect(component_2.className).toBe('sx03kze sx03kzetmy8g--size-small')
-		expect(STITCHES.toString()).toBe(stylerule_2)
+		expect(expression.className).toBe('sx03kze sx03kzetmy8g--size-small')
+		expect(toString()).toBe('.sx03kzetmy8g--size-small{font-size:16px;}')
 	})
 
 	test('Renders a component with the non-default variant explicitly applied', () => {
-		component_3 = component({ size: 'large' })
-		stylerule_3 = stylerule_2 + '.sx03kzefhyhx--size-large{font-size:24px;}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ size: 'large' })
 
-		expect(component_3.className).toBe('sx03kze sx03kzefhyhx--size-large')
-		expect(STITCHES.toString()).toBe(stylerule_3)
+		expect(expression.className).toBe('sx03kze sx03kzefhyhx--size-large')
+		expect(toString()).toBe('.sx03kzefhyhx--size-large{font-size:24px;}')
 	})
 
 	test('Renders a component with the default variant applied and a different variant explicitly applied', () => {
-		component_4 = component({ level: 1 })
-		stylerule_4 = stylerule_3 + '.sx03kzehmqox--level-1{padding:0.5em;}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ level: 1 })
 
-		expect(component_4.className).toBe('sx03kze sx03kzehmqox--level-1 sx03kzetmy8g--size-small')
-		expect(STITCHES.toString()).toBe(stylerule_4)
-	})
-
-	test('Renders a component with the default variant applied and a different variant explicitly applied', () => {
-		component_4 = component({ level: 1 })
-		stylerule_4 = stylerule_3 + '.sx03kzehmqox--level-1{padding:0.5em;}'
-
-		expect(component_4.className).toBe('sx03kze sx03kzehmqox--level-1 sx03kzetmy8g--size-small')
-		expect(STITCHES.toString()).toBe(stylerule_4)
+		expect(expression.className).toBe('sx03kze sx03kzehmqox--level-1 sx03kzetmy8g--size-small')
+		expect(toString()).toBe(
+			[
+				// explicit level:1
+				'.sx03kzehmqox--level-1{padding:0.5em;}',
+				// implicit size:small
+				'.sx03kzetmy8g--size-small{font-size:16px;}',
+			].join(''),
+		)
 	})
 
 	test('Renders a component with the default variant applied, a different variant explicitly applied, and a compound applied', () => {
-		component_5 = component({ color: 'blue' })
-		stylerule_5 = stylerule_4 + '.sx03kze4wpam--color-blue{background-color:dodgerblue;color:white;}' + '.sx03kzeif1wl--comp{transform:scale(1.2);}'
+		const { css, toString } = createCss()
+		const component = css(componentConfig)
+		const expression = component({ color: 'blue' })
 
-		expect(component_5.className).toBe('sx03kze sx03kzeif1wl--comp sx03kze4wpam--color-blue sx03kzetmy8g--size-small')
-		expect(STITCHES.toString()).toBe(stylerule_5)
+		expect(expression.className).toBe('sx03kze sx03kzeif1wl--comp sx03kze4wpam--color-blue sx03kzetmy8g--size-small')
+		expect(toString()).toBe(
+			[
+				// explicit color:blue
+				'.sx03kze4wpam--color-blue{background-color:dodgerblue;color:white;}',
+				// implicit size:small
+				'.sx03kzetmy8g--size-small{font-size:16px;}',
+				// compound color:blue + size:small
+				'.sx03kzeif1wl--comp{transform:scale(1.2);}',
+			].join(''),
+		)
 	})
 })
 

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -50,12 +50,16 @@ const createCss = (init) => {
 			/** Returns a React component. */
 			(
 				/** Type of component. */
-				asType = 'span',
+				asType,
 				/** Component styles. */
 				initStyles,
 			) => {
+				const isComposition = 'composes' in Object(asType)
+
 				/** Expression used to activate the component CSS on the current styled sheet. */
-				const expression = sheet.css(asType, initStyles)
+				const composition = isComposition ? sheet.css(asType.composes, initStyles) : sheet.css(initStyles)
+
+				const defaultType = (asType === Object(asType) ? asType.type : asType) || 'span'
 
 				/** Returns a React element. */
 				return Object.setPrototypeOf(
@@ -68,30 +72,32 @@ const createCss = (init) => {
 						) {
 							// express the component, extracting `props`, `as` & `ref`
 							const {
-								props: { as: type = asType, ...props },
+								props: { as: type = defaultType, ...props },
 								...expressedProps
-							} = expression(initProps)
+							} = composition(initProps)
 
 							// sync the dynamic stylesheet
 							sheet.sync()
 
 							/** React element. */
-							return { ...expressedProps, constructor: undefined, $$typeof, props, ref, type, __v: 0 }
+							return { constructor: undefined, $$typeof, props, ref, type, __v: 0 }
 						},
 						[Symbol.toPrimitive]() {
-							return expression.selector
+							return composition.selector
 						},
 						toString() {
-							return expression.selector
+							return composition.selector
 						},
 						get className() {
-							return expression.className
+							return composition.className
 						},
 						get selector() {
-							return expression.selector
+							return composition.selector
 						},
-						classNames: expression.classNames,
-						variants: expression.variants,
+						composes: composition,
+						classNames: composition.classNames,
+						variants: composition.variants,
+						type: defaultType,
 					},
 					Object(asType),
 				)

--- a/packages/react/tests/as-props.js
+++ b/packages/react/tests/as-props.js
@@ -1,0 +1,34 @@
+import createCss from '../src/index.js'
+
+describe('As prop', () => {
+	test('The "as" property can be used or overridden', () => {
+		const { styled } = createCss()
+		const component1 = styled()
+
+		const expression1 = component1.render()
+
+		expect(expression1.type).toBe('span')
+
+		const component2 = styled('div')
+		const expression2 = component2.render()
+
+		expect(expression2.type).toBe('div')
+
+		const expression2a = component2.render({ as: 'span' })
+
+		expect(expression2a.type).toBe('span')
+	})
+
+	test('The "as" property is followed during extension', () => {
+		const { styled } = createCss()
+		const component1 = styled('div')
+		const component2 = styled(component1)
+		const expression = component2.render()
+
+		expect(expression.type).toBe('div')
+
+		const expression2a = component2.render({ as: 'span' })
+
+		expect(expression2a.type).toBe('span')
+	})
+})


### PR DESCRIPTION
This PR fixes an issue where a default variant value would apply over the explicitly set value when it was used on its own. This also updates the variants test to be easier to read and update in isolation.