### PR TITLE
fix: extending regular react components

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -59,7 +59,7 @@ const createCss = (init) => {
 				/** Expression used to activate the component CSS on the current styled sheet. */
 				const composition = isComposition ? sheet.css(asType.composes, initStyles) : sheet.css(initStyles)
 
-				const defaultType = (asType === Object(asType) ? asType.type : asType) || 'span'
+				const defaultType = (isComposition ? asType.type : asType) || 'span'
 
 				/** Returns a React element. */
 				return Object.setPrototypeOf(

--- a/packages/react/tests/components.js
+++ b/packages/react/tests/components.js
@@ -1,0 +1,31 @@
+import createCss from '../src/index.js'
+
+describe('Components', () => {
+	test('The `styled` function returns an implicit span component', () => {
+		const { styled } = createCss()
+		const component = styled()
+
+		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
+		expect(component.type).toBe('span')
+	})
+
+	test('The `styled` function can return an explicit div component', () => {
+		const { styled } = createCss()
+		const component = styled('div')
+
+		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
+		expect(component.type).toBe('div')
+	})
+
+	test('The `styled` function can return an explicit React component', () => {
+		function TextComponent() {
+			return 'text'
+		}
+
+		const { styled } = createCss()
+		const component = styled(TextComponent)
+
+		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
+		expect(component.type).toBe(TextComponent)
+	})
+})


### PR DESCRIPTION
This PR fixes an issue introduced in canary.3 where standard react components could not be extended. As with every step forward, this PR introduces tests to ensure this regression would not happen again.

Resolves  #387