### PR TITLE
fix: undefined variant value uses the default value

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -276,8 +276,8 @@ const createCss = (init) => {
 
 			for (const propName in props) {
 				if (propName in variants) {
-					const propValue = props[propName]
 					const variant = variants[propName]
+					const propValue = props[propName] === undefined && !(undefined in variant) ? defaultVariants[propName] : props[propName]
 
 					if (propName !== 'as') delete props[propName]
 

--- a/packages/react/tests/variants.js
+++ b/packages/react/tests/variants.js
@@ -1,0 +1,62 @@
+import createCss from '../src/index.js'
+
+describe('Variants', () => {
+	test('Variant given undefined will revert to the default', () => {
+		const { styled } = createCss()
+		const component = styled('div', {
+			variants: {
+				color: {
+					blue: {
+						color: 'blue',
+					},
+					red: {
+						color: 'red',
+					},
+				},
+			},
+			defaultVariants: {
+				color: 'blue',
+			},
+		})
+
+		const expression1 = component.render()
+		expect(expression1.props.className).toBe('sx03kze sx03kze11nwi--color-blue')
+
+		const expression2 = component.render({ color: 'red' })
+		expect(expression2.props.className).toBe('sx03kze sx03kze3ye05--color-red')
+
+		const expression3 = component.render({ color: undefined })
+		expect(expression3.props.className).toBe('sx03kze sx03kze11nwi--color-blue')
+	})
+
+	test('Variant with an explicit undefined will work', () => {
+		const { styled } = createCss()
+		const component = styled('div', {
+			variants: {
+				color: {
+					blue: {
+						color: 'blue',
+					},
+					red: {
+						color: 'red',
+					},
+					undefined: {
+						color: 'transparent',
+					},
+				},
+			},
+			defaultVariants: {
+				color: 'blue',
+			},
+		})
+
+		const expression1 = component.render()
+		expect(expression1.props.className).toBe('sx03kze sx03kze11nwi--color-blue')
+
+		const expression2 = component.render({ color: 'red' })
+		expect(expression2.props.className).toBe('sx03kze sx03kze3ye05--color-red')
+
+		const expression3 = component.render({ color: undefined })
+		expect(expression3.props.className).toBe('sx03kze sx03kzer02wp--color-undefined')
+	})
+})


### PR DESCRIPTION
This PR changes variant values of `undefined` to use its corresponding `defaultVariant` value if it is available. This was a useful feature included prior to the v0.1.0 versions of stitches.

Resolves #385