### PR TITLE
fix: initial condition not typed

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -168,7 +168,11 @@ export type EmptyTheme = {
 	transitions?: {}
 }
 
-export type TConditions = { [k: string]: string }
+export type TConditions = {
+	/** This condition will always apply. */
+	initial: string
+	[k: string]: string
+}
 export type TTheme = { [k in keyof EmptyTheme]?: { [b: string]: string } }
 export type TThemeMap = { [k in keyof Properties]?: keyof EmptyTheme }
 /** Configuration of Stitches, including a default theme, prefix, custom conditions, and functional properties. */


### PR DESCRIPTION
This PR adds typing support for the `initial` condition, which resolves #374.