### PR TITLE
Fix auto complete with polymorphism 

### DIFF
--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import createStyled, { StitchesCss, StitchesVariants } from '../types/index.d'
+import createStyled, { StitchesCss, StitchesVariants, StitchesComponentWithAutoCompleteForReactComponents, StitchesComponentWithAutoCompleteForJSXElements } from '../types/index.d'
 import * as SeparatorPrimitive from '@radix-ui/react-separator'
 import type * as Polymorphic from '@radix-ui/react-polymorphic'
 
@@ -176,7 +176,7 @@ const Button = styled('button', {
 const ExtendedButton = styled(Button, {
 	variants: {
 		variant: {
-			blue: {
+			green: {
 				color: 'ActiveBorder',
 				backgroundColor: 'ActiveCaption',
 			},
@@ -251,7 +251,7 @@ export function Test() {
 			<Button form="form" onClick={(e) => {}} />
 
 			{/* Button accepts css prop */}
-			<Button css={{ backgroundColor: 'ActiveCaption', padding: 'inherit' }} />
+			<Button css={{ backgroundColor: 'ActiveCaption', padding: 'inherit', paddingBlock: 'inherit', color: 'ActiveCaption' }} />
 
 			{/* Button accepts isDisabled prop */}
 			<Button isDisabled />
@@ -289,7 +289,7 @@ export function Test() {
 			<Button as={Link} onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => event.altKey} />
 
 			{/* ExtendedButton accepts variant prop */}
-			<ExtendedButton variant="red" />
+			<ExtendedButton variant="green" />
 
 			{/* ExtendedButton accepts isDisabled prop */}
 			<ExtendedButton isDisabled />

--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -61,10 +61,6 @@ type CSS = StitchesCss<typeof factory>
 
 export const { styled, toString, theme, css, keyframes, global, config } = factory
 
-const RComponent: React.FC<{ hola?: 'hi' | 'hello' }> = () => {
-	return null
-}
-
 const StyledSeparator = styled(SeparatorPrimitive.Root, {
 	border: 'none',
 	margin: 0,
@@ -184,12 +180,20 @@ const ExtendedButton = styled(Button, {
 	},
 })
 
-const ReactComponent: React.FC = (props) => <div></div>
+const Box = styled('div', {})
+
+const ReactComponent: React.FC<{ fromReact?: boolean }> = (props) => <div></div>
 
 const StitchesExtendingReactComponent = styled(ReactComponent, {
 	backgroundColor: 'red',
 	backgroundOrigin: 'border-box',
 	backdropFilter: 'inherit',
+	variants: {
+		fromStitches: {
+			true: {},
+			false: {},
+		},
+	},
 })
 
 type Props = React.ComponentProps<typeof StitchesExtendingReactComponent>
@@ -201,22 +205,6 @@ type Props = React.ComponentProps<typeof StitchesExtendingReactComponent>
 const ExtendedButtonUsingReactUtils = React.forwardRef<React.ElementRef<typeof Button>, React.ComponentProps<typeof Button>>((props, forwardedRef) => {
 	return <Button />
 })
-
-/* -------------------------------------------------------------------------------------------------
- * Extended Button using react utilities without polymorphism and inline `as`
- * -----------------------------------------------------------------------------------------------*/
-export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(props: React.ComponentProps<typeof Button>) {
-	/* Should not error with inline `as` component */
-	return <Button as={(_props) => <a {..._props} />} />
-}
-
-/* --------------------------------------------------now it's not likeikng -----------------------------------------------
- * Extended Polymorphic Button
- * -----------------------------------------------------------------------------------------------*/
-
-/* -------------------------------------------------------------------------------------------------
- * Normal Link
- * -----------------------------------------------------------------------------------------------*/
 
 type LinkProps = React.ComponentProps<'a'> & {
 	isPrimary?: boolean
@@ -243,6 +231,10 @@ export function Test() {
 			{/* Link accepts isPrimary prop */}
 			<Link isPrimary />
 
+			<Box as={Button} form="">
+				hello
+			</Box>
+
 			{/* Button does not accept href prop */}
 			{/* @ts-expect-error */}
 			<Button as="div" href="" />
@@ -257,10 +249,10 @@ export function Test() {
 			<Button isDisabled />
 
 			{/* Button accepts a responsive variant */}
-			<Button variant={{ bp1: 'red' }} />
+			<Button variant={{ bp1: 'red' }} css={{ backdropFilter: 'initial', backgroundColor: 'AppWorkspace' }} />
 
 			{/* Button as "a" accepts href prop */}
-			<Button as="a" href="f" />
+			<Button as="a" href="" />
 
 			{/* Button as "a" does not accept form prop */}
 			{/* @ts-expect-error */}
@@ -288,8 +280,9 @@ export function Test() {
 			{/* Button as Link accepts onClick prop, but it must be explicitly typed */}
 			<Button as={Link} onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => event.altKey} />
 
-			{/* ExtendedButton accepts variant prop */}
+			{/* ExtendedButton combines variants */}
 			<ExtendedButton variant="green" />
+			<ExtendedButton variant="red" />
 
 			{/* ExtendedButton accepts isDisabled prop */}
 			<ExtendedButton isDisabled />
@@ -327,6 +320,8 @@ export function Test() {
 					console.log(e)
 				}}
 			/>
+
+			<StitchesExtendingReactComponent fromReact fromStitches />
 			{/** As errors on extended element when passed a wrong prop */}
 			{/* @ts-expect-error */}
 			<StitchesExtendingReactComponent href="fwef" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "sourceMap": true,
     "inlineSources": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR fixes autocompletion in the best way possible with the current limitation of how TS only shows auto-completion for the first overload.

this PR works by changing the interface that we create when we call `styled(T, {})` based on the value of T

**Two main interfaces used here:**
- so if T is a react component then the resulting typed interface is `StitchesComponentWithAutoCompleteForReactComponents`
- and if T is a Stitches component or a JSX intrinsic element then the resulting typed  interface will be `StitchesComponentWithAutoCompleteForJSXElements`

**How events will be typed:**
- events with the as prop will be typed if the as prop was a JSX intrinsic element
- events will be any if the as prop is a component or if the stitches component was extending another non-stitches component using `styled(Component,{})`

**how autocompletion works:**
- for normal usages without the as prop autocompletion should work completely and everything should be typed
- when there is an as prop and for components using `StitchesComponentWithAutoCompleteForReactComponents`, autocomplete will work for as props that have a react component as a value
- when there is an as prop and for components using  `StitchesComponentWithAutoCompleteForJSXElements`, autocomplete will work for as props that have a jsx element as a value


**Type checking:**
- should always work and error correctly regardless of the stitches interface used to construct the type
