### PR TITLE
Support recursive and complex nesting

### DIFF
--- a/packages/core/src/getResolvedSelectors.js
+++ b/packages/core/src/getResolvedSelectors.js
@@ -6,7 +6,15 @@ const getResolvedSelectors = (
 	nestedSelectors,
 ) =>
 	parentSelectors.reduce((resolvedSelectors, parentSelector) => {
-		resolvedSelectors.push(...nestedSelectors.map((selector) => (/&/.test(selector) ? selector.replace(/&/, parentSelector) : selector.replace(/^/, parentSelector + ' '))))
+		resolvedSelectors.push(...nestedSelectors.map(
+			(selector) => (
+				/[ +>|~]/.test(parentSelector) && /&[^]*&/.test(selector)
+					? selector.replace(/&/g, `:is(${parentSelector})`)
+				: /&/.test(selector)
+					? selector.replace(/&/g, parentSelector)
+					: selector.replace(/^/, parentSelector + ' ')
+			)
+		))
 		return resolvedSelectors
 	}, [])
 

--- a/packages/core/tests/nesting.js
+++ b/packages/core/tests/nesting.js
@@ -1,0 +1,93 @@
+import createCss from '../src/index.js'
+
+describe('Nesting', () => {
+	test('Authors can define global nesting rules', () => {
+		const { global, toString } = createCss({})
+
+		global({
+			'body > a': {
+				'&:not(:hover)': {
+					textDecoration: 'none',
+				}
+			}
+		})()
+
+		expect(toString()).toBe(`body > a:not(:hover){text-decoration:none;}`)
+	})
+
+	test('Authors can define component nesting rules', () => {
+		const { css, toString } = createCss({})
+
+		css({
+			'&:not(:hover)': {
+				textDecoration: 'none',
+			}
+		})()
+
+		expect(toString()).toBe(`.sxnz0bq:not(:hover){text-decoration:none;}`)
+	})
+
+	test('Authors can define recursive global nesting rules', () => {
+		const { global, toString } = createCss({})
+
+		global({
+			'p': {
+				margin: 0,
+				'& ~ &': {
+					marginTop: 0,
+				}
+			}
+		})()
+
+		expect(toString()).toBe(`p{margin:0;}p ~ p{margin-top:0;}`)
+	})
+
+	test('Authors can define recursive component nesting rules', () => {
+		const { css, toString } = createCss({})
+
+		css({
+			margin: 0,
+			'& ~ &': {
+				marginTop: 0,
+			}
+		})()
+
+		expect(toString()).toBe(`.sxxgatx{margin:0;}.sxxgatx ~ .sxxgatx{margin-top:0;}`)
+	})
+
+	test('Authors can define complex recursive global nesting rules', () => {
+		const { global, toString } = createCss({})
+
+		global({
+			'body > p, body > ul': {
+				margin: 0,
+				'& ~ &': {
+					marginTop: 0,
+				}
+			}
+		})()
+
+		const parentCssRule = `body > p, body > ul{margin:0;}`
+		const nestingCssRule = `:is(body > p) ~ :is(body > p), :is(body > ul) ~ :is(body > ul){margin-top:0;}`
+
+		expect(toString()).toBe(parentCssRule + nestingCssRule)
+	})
+
+	test('Authors can define complex recursive component nesting rules', () => {
+		const { css, toString } = createCss({})
+
+		css({
+			'& > p, & > ul': {
+				margin: 0,
+				'& ~ &': {
+					marginTop: 0,
+				}
+			}
+		})()
+
+		const parentCssRule = `.sxp5b35 > p, .sxp5b35 > ul{margin:0;}`
+		const nestingCssRule = `:is(.sxp5b35 > p) ~ :is(.sxp5b35 > p), :is(.sxp5b35 > ul) ~ :is(.sxp5b35 > ul){margin-top:0;}`
+
+		expect(toString()).toBe(parentCssRule + nestingCssRule)
+	})
+})


### PR DESCRIPTION
This PR adds support for recursive nesting to Stitches. This will behave as CSS nesting is intended to behave per [spec](https://drafts.csswg.org/css-nesting/), likely making Stitches the very first CSS library to fully support this feature.

Here’s an example of complex, recursive nesting:

```js
const globalStyles = global({
  'article p, article ul': {
    margin: 0,
    '& ~ &': {
      marginTop: '2em',
    }
  }
})

const component = css({
  '& p, & ul': {
    margin: 0,
    '& ~ &': {
      marginTop: '2em',
    }
  }
})
```

In both rules, descendant paragraphs and unordered lists should not have any margin, except when they are proceeding siblings of each other that are also descendants of the same ancestor. 👀 

Resolves #372