### PR TITLE
fix: boolean & numeric type variant, default/compound variant support

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -425,10 +425,12 @@ export interface TStyledSheet<A extends TConditions = {}, B extends TTheme = {},
 	/** Prefix applied to all styled and themed rules. */
 	prefix: string
 }
-type MorphVariants<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T
+
+export type StrictMorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | true : T extends 'false' ? 'false' | false : T
+export type MorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T
 
 export type VariantsCall<Variants, Conditions> = {
-	[k in keyof Variants]?: MorphVariants<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariants<keyof Variants[k]> }
+	[k in keyof Variants]?: MorphVariant<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariant<keyof Variants[k]> }
 }
 
 /** Extracts the css type from the  */

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -427,7 +427,7 @@ export interface TStyledSheet<A extends TConditions = {}, B extends TTheme = {},
 }
 
 export type StrictMorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | true : T extends 'false' ? 'false' | false : T
-export type MorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T
+export type MorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T extends `${number}` ? number : T
 
 export type VariantsCall<Variants, Conditions> = {
 	[k in keyof Variants]?: MorphVariant<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariant<keyof Variants[k]> }

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { InternalCSS, LessInternalCSS, TConditions, TTheme, TStyledSheet, VariantsCall, IConfig, TThemeMap, CSSPropertiesToTokenScale, $variants, $conditions, StitchesExtractVariantsStyles } from '@stitches/core'
+import { InternalCSS, LessInternalCSS, TConditions, TTheme, TStyledSheet, VariantsCall, IConfig, TThemeMap, CSSPropertiesToTokenScale, $variants, $conditions, StitchesExtractVariantsStyles, StrictMorphVariant } from '@stitches/core'
 
 export * from '@stitches/core'
 
@@ -148,13 +148,13 @@ export type StyledInstance<Conditions = {}, Theme extends TTheme = {}, Utils = {
 			}
 			& {
 						defaultVariants?: {
-							[k in keyof CloneVariants]?: keyof CloneVariants[k]
+							[k in keyof CloneVariants]?: StrictMorphVariant<keyof CloneVariants[k]>
 						}
 					}
 					& {
 						compoundVariants?: (
 							{
-								[k in keyof CloneVariants]?: keyof CloneVariants[k]
+								[k in keyof CloneVariants]?: StrictMorphVariant<keyof CloneVariants[k]>
 							}
 							& {
 								css?: InternalCSS<Conditions, Theme, Utils, ThemeMap>


### PR DESCRIPTION
This PR updates our typings to support boolean and numeric variant values when using TypeScript.

Examples:

```tsx
Test = styled("div", {
  variants: {
    defined: {
      undefined: {}
    },
    strong: {
      true: {}
    },
    weight: {
      400: {},
    },
  },
  defaultVariants: {
    strong: true,
    defined: void 0
  },
  compoundVariants: [
    {
      strong: true,
      defined: undefined,
      css: {}
    }]
})
```

```tsx
<Test weight={500} />
```

Resolves #384
Resolves #403