### PR TITLE
fix: support numeric tokens in themes

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -173,7 +173,7 @@ export type TConditions = {
 	initial: string
 	[k: string]: string
 }
-export type TTheme = { [k in keyof EmptyTheme]?: { [b: string]: string } }
+export type TTheme = { [k in keyof EmptyTheme]?: { [b: string]: number | string } }
 export type TThemeMap = { [k in keyof Properties]?: keyof EmptyTheme }
 /** Configuration of Stitches, including a default theme, prefix, custom conditions, and functional properties. */
 export interface IConfig<Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap = {}> {


### PR DESCRIPTION
This PR updates the typings to support numeric tokens in themes with TypeScript.

Example:
```tsx
import { createCss } from '@stitches/react'

const { styled, css } = createCss({
  theme: {
    fontWeights: {
      light: 300,
      regular: 400,
      semibold: 600,
      bold: 700,
    },
  },
})
```

Resolves #226