### PR TITLE
fix: allow custom props in conditions in TS

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -254,7 +254,13 @@ export type FlatInternalCSS<
 } & {
 	/** Responsive variants: */
 	when?: {
-		[k in keyof Conditions]?: FlatInternalCSS<Conditions, Theme, Utils, ThemeMap>
+		[k in keyof Conditions]?: (
+			FlatInternalCSS<Conditions, Theme, Utils, ThemeMap>
+			& {
+				/** Unknown property. */
+				[k in string]: unknown
+			}
+		)
 	}
 } & {
 	[k in keyof Utils]?: Utils[k]


### PR DESCRIPTION
This PR updates the typescript typings for conditions so that using custom properties do not throw an error.