### PR TITLE
fix: issue with "morph" variants autocomplete and erroring

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -432,8 +432,8 @@ export interface TStyledSheet<A extends TConditions = {}, B extends TTheme = {},
 	prefix: string
 }
 
-export type StrictMorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | true : T extends 'false' ? 'false' | false : T
-export type MorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? 'true' | boolean : T extends 'false' ? 'false' | boolean : T extends `${number}` ? number : T
+export type StrictMorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? true | T : T extends 'false' ? false | T : T
+export type MorphVariant<T> = T extends number ? `${T}` | T : T extends 'true' ? boolean | T : T extends 'false' ? boolean | T : T extends `${number}` ? number | T : T
 
 export type VariantsCall<Variants, Conditions> = {
 	[k in keyof Variants]?: MorphVariant<keyof Variants[k]> | { [I in keyof Conditions]?: MorphVariant<keyof Variants[k]> }


### PR DESCRIPTION
This PR updates the TypeScript `MorphVariant` and `StrictMorphVariant` utilities to fix an issue where certain number/string combinations would throw a TS error or fail to autocomplete.

Resolves #421