### PR TITLE
Add test coverage benchmarking

### DIFF
--- a/.bin/color.js
+++ b/.bin/color.js
@@ -1,0 +1,32 @@
+const color = new Proxy(
+	Object.entries({
+		reset: 0,
+		bold: 1,
+		dim: 2,
+		underline: 4,
+		blink: 5,
+		invert: 7,
+		hidden: 8,
+		black: 30,
+		red: 31,
+		green: 32,
+		yellow: 33,
+		blue: 34,
+		magenta: 35,
+		cyan: 36,
+		white: 37,
+		bgBlack: 40,
+		bgRed: 41,
+		bgGreen: 42,
+		bgYellow: 43,
+		bgBlue: 44,
+		bgMagenta: 45,
+		bgCyan: 46,
+		bgWhite: 47,
+	}).reduce((color, [name, id]) => ({ ...color, [name]: `\x1b[${id}m` }), {}),
+	{
+		get: (colors, name) => (string) => colors[name] + string.replaceAll(colors.reset, colors.reset + colors[name]) + colors.reset,
+	},
+)
+
+export default color

--- a/.bin/color.js
+++ b/.bin/color.js
@@ -1,32 +1,25 @@
-const color = new Proxy(
-	Object.entries({
-		reset: 0,
-		bold: 1,
-		dim: 2,
-		underline: 4,
-		blink: 5,
-		invert: 7,
-		hidden: 8,
-		black: 30,
-		red: 31,
-		green: 32,
-		yellow: 33,
-		blue: 34,
-		magenta: 35,
-		cyan: 36,
-		white: 37,
-		bgBlack: 40,
-		bgRed: 41,
-		bgGreen: 42,
-		bgYellow: 43,
-		bgBlue: 44,
-		bgMagenta: 45,
-		bgCyan: 46,
-		bgWhite: 47,
-	}).reduce((color, [name, id]) => ({ ...color, [name]: `\x1b[${id}m` }), {}),
-	{
-		get: (colors, name) => (string) => colors[name] + string.replaceAll(colors.reset, colors.reset + colors[name]) + colors.reset,
-	},
-)
+export const set = (id) => `\x1b[${id}m`
+export const color = (string, id) => set(id) + string.replaceAll(set(0), set(0) + set(id)) + set(0)
 
-export default color
+export const bold = (string) => color(string, 1)
+export const dim = (string) => color(string, 2)
+export const underline = (string) => color(string, 4)
+export const invert = (string) => color(string, 7)
+
+export const black = (string) => color(string, 30)
+export const red = (string) => color(string, 31)
+export const green = (string) => color(string, 32)
+export const yellow = (string) => color(string, 33)
+export const blue = (string) => color(string, 34)
+export const magenta = (string) => color(string, 35)
+export const cyan = (string) => color(string, 36)
+export const white = (string) => color(string, 37)
+
+export const bgBlack = (string) => color(string, 40)
+export const bgRed = (string) => color(string, 41)
+export const bgGreen = (string) => color(string, 42)
+export const bgYellow = (string) => color(string, 43)
+export const bgBlue = (string) => color(string, 44)
+export const bgMagenta = (string) => color(string, 45)
+export const bgCyan = (string) => color(string, 46)
+export const bgWhite = (string) => color(string, 47)

--- a/.bin/coverage.js
+++ b/.bin/coverage.js
@@ -2,7 +2,7 @@ import cp from 'child_process'
 import fp from 'path'
 import fs from 'fs/promises'
 import os from 'os'
-import cc from './color.js'
+import { bold, dim, green, red } from './color.js'
 
 // Creates a unique temporary directory
 !(async () => {
@@ -155,17 +155,17 @@ import cc from './color.js'
 		const sol = Math.trunc(per / 10)
 		const haf = per % 10 >= 5 ? 1 : 0
 		const emt = 10 - sol - haf
-		return [`▰`.repeat(sol), `▱`.repeat(haf), cc.dim(`▱`.repeat(emt))].join('')
+		return [`▰`.repeat(sol), `▱`.repeat(haf), dim(`▱`.repeat(emt))].join('')
 	}
 
 	/** Returns the ratio of 2 fields in LCOV data. */
-	const ratio = (lcov, l, r) => `${lcov[l]}${cc.dim('/')}${lcov[r]}`.padStart(17)
+	const ratio = (lcov, l, r) => `${lcov[l]}${dim('/')}${lcov[r]}`.padStart(17)
 
 	/** Based on the given LCOV data, returns the given data in a shade of green or red. */
-	const shade = (lcov, data) => (lcov.FNH / lcov.FNF > 0.6 ? cc.green : cc.red)(data)
+	const shade = (lcov, data) => (lcov.FNH / lcov.FNF > 0.6 ? green : red)(data)
 
 	const trtd = (lcov) =>
-		cc.dim('│ ') +
+		dim('│ ') +
 		shade(
 			lcov,
 			lcov.SF[0]
@@ -175,17 +175,19 @@ import cc from './color.js'
 		) +
 		' ' +
 		shade(lcov, meter(lcov)) +
-		cc.dim(' │ ') +
+		dim(' │ ') +
 		shade(lcov, ratio(lcov, 'FNH', 'FNF')) +
-		cc.dim(' │ ') +
+		dim(' │ ') +
 		shade(lcov, ratio(lcov, 'LH', 'LF')) +
-		cc.dim(' │')
+		dim(' │')
+
+	lcovList.sort((a, b) => a.SF[0] - b.SF[0])
 
 	console.log(
 		[
-			[cc.dim('╭'), cc.dim('─'.repeat(44)), cc.dim('┬'), cc.dim('─'.repeat(11)), cc.dim('┬'), cc.dim('─'.repeat(11)), cc.dim('╮')].join(''),
-			[cc.dim('│'), cc.bold('Coverage') + ' '.repeat(34), cc.dim('│'), cc.bold('Functions'), cc.dim('│'), ' '.repeat(4) + cc.bold('Lines'), cc.dim('│')].join(' '),
-			[cc.dim('├'), cc.dim('─'.repeat(44)), cc.dim('┼'), cc.dim('─'.repeat(11)), cc.dim('┼'), cc.dim('─'.repeat(11)), cc.dim('┤')].join(''),
+			[dim('╭'), dim('─'.repeat(44)), dim('┬'), dim('─'.repeat(11)), dim('┬'), dim('─'.repeat(11)), dim('╮')].join(''),
+			[dim('│'), bold('Coverage') + ' '.repeat(34), dim('│'), bold('Functions'), dim('│'), ' '.repeat(4) + bold('Lines'), dim('│')].join(' '),
+			[dim('├'), dim('─'.repeat(44)), dim('┼'), dim('─'.repeat(11)), dim('┼'), dim('─'.repeat(11)), dim('┤')].join(''),
 			trtd(
 				lcovList.reduce(
 					(all, lcov) => {
@@ -198,9 +200,9 @@ import cc from './color.js'
 					{ TN: [''], SF: ['All files'], FN: [], FNDA: [], FNF: [0], FNH: [0], DA: [], LH: [0], LF: [0] },
 				),
 			),
-			[cc.dim('╞'), ' '.repeat(42), cc.dim('╪'), ' '.repeat(9), cc.dim('╪'), ' '.repeat(9), cc.dim('╡')].join(' '),
+			[dim('╞'), ' '.repeat(42), dim('╪'), ' '.repeat(9), dim('╪'), ' '.repeat(9), dim('╡')].join(' '),
 			...lcovList.map((lcov) => trtd(lcov)),
-			[cc.dim('╰'), cc.dim('─'.repeat(44)), cc.dim('┴'), cc.dim('─'.repeat(11)), cc.dim('┴'), cc.dim('─'.repeat(11)), cc.dim('╯')].join(''),
+			[dim('╰'), dim('─'.repeat(44)), dim('┴'), dim('─'.repeat(11)), dim('┴'), dim('─'.repeat(11)), dim('╯')].join(''),
 		].join('\n'),
 	)
 })()

--- a/.bin/coverage.js
+++ b/.bin/coverage.js
@@ -1,0 +1,206 @@
+import cp from 'child_process'
+import fp from 'path'
+import fs from 'fs/promises'
+import os from 'os'
+import cc from './color.js'
+
+// Creates a unique temporary directory
+!(async () => {
+	/** Directory storing code coverage. */
+	const NODE_V8_COVERAGE = await fs.mkdtemp(os.tmpdir())
+
+	/** Exit code from the covered NodeJS process. */
+	await new Promise((close, error) => {
+		cp.spawn('node', process.argv.slice(2), {
+			stdio: 'inherit',
+			env: { ...process.env, NODE_V8_COVERAGE },
+		})._events = { close, error }
+	})
+
+	/** Combined coverage results */
+	const results = []
+
+	for (const filename of await fs.readdir(NODE_V8_COVERAGE)) {
+		results.push(...JSON.parse(await fs.readFile(fp.join(NODE_V8_COVERAGE, filename), 'utf8')).result)
+	}
+
+	await fs.rmdir(NODE_V8_COVERAGE, { recursive: true })
+
+	/** Combined LCOV results. */
+	let lcovList = []
+
+	/** Combined LCOV results. */
+	let lcovInfo = ''
+
+	/** Filter for filtered results */
+	const filter = (url) => !url.protocol.startsWith('node') && !url.pathname.includes('/node_modules/') && url.pathname.includes('/src/')
+
+	for (let result of results) {
+		/** URL classed result URL */
+		const url = new URL(result.url)
+
+		if (filter(url)) {
+			/** Contents of the file whose coverage was collected. */
+			const data = await fs.readFile(url, 'utf8')
+
+			/** List of code lines, where the line of code is a `data` property on the object. */
+			const rows = data.split(/^/gm).map((line) => ({ data: line }))
+
+			const lcov = {
+				/** Test name */
+				TN: [''],
+
+				/** Source file */
+				SF: [url.pathname],
+
+				/** Line numbers for each function name. */
+				FN: [],
+
+				/** Execution count for the given function.*/
+				FNDA: [],
+
+				/** Number of functions found. */
+				FNF: [0],
+
+				/** Number of functions hit. */
+				FNH: [0],
+
+				/** Execution count for the given line. */
+				DA: [],
+
+				/** Number of collected lines with a positive execution count. */
+				LH: [0],
+
+				/** Number of collected lines. */
+				LF: [0],
+			}
+
+			lcovList.push(lcov)
+
+			/** Convert */
+			const convert = (range, isFirstRun) => {
+				let lineOffset = 0
+
+				for (const lineIndex in rows) {
+					const nextLineOffset = lineOffset + rows[lineIndex].data.length
+
+					if (range.startLine == null && range.startOffset >= lineOffset && range.startOffset < nextLineOffset) {
+						range.startLine = Number(lineIndex) + 1
+						range.startCol = range.startOffset - lineOffset + 1
+					}
+
+					if (range.endOffset >= lineOffset && range.endOffset < nextLineOffset) {
+						range.endLine = Number(lineIndex) + 1
+						range.endCol = range.endOffset - lineOffset + 1
+
+						if (!isFirstRun) {
+							for (let j = range.startLine; j <= range.endLine; ++j) {
+								if (rows[j]) {
+									if (!range.count) {
+										rows[j].exec = 0
+									} else if (rows[j].exec == null) {
+										rows[j].exec = range.count
+									} else if (rows[j].exec > 0) {
+										rows[j].exec += range.count
+									}
+								}
+							}
+						}
+
+						break
+					}
+
+					lineOffset = nextLineOffset
+				}
+
+				return range
+			}
+
+			for (const coverage of result.functions) {
+				let startRange = convert(coverage.ranges[0], true)
+				let count = 0
+
+				++lcov.FNF[0]
+
+				lcov.FN.push([startRange.startLine, coverage.functionName])
+
+				for (const range of coverage.ranges) {
+					count += convert(range).count
+				}
+
+				lcov.FNDA.push([count, coverage.functionName])
+
+				if (count) ++lcov.FNH[0]
+			}
+
+			for (const line in rows) {
+				++lcov.LF[0]
+
+				if ('exec' in rows[line]) {
+					lcov.DA.push([line, rows[line].exec])
+
+					if (rows[line].exec) ++lcov.LH[0]
+				}
+			}
+
+			lcovInfo += `${Object.entries(lcov).reduce((report, [name, data]) => report.concat(data.reduce((string, each) => string.concat(`${name.toUpperCase()}:${each}\n`), '')), '')}end_of_record\n`
+		}
+	}
+
+	fs.writeFile('coverage/lcov.info', lcovInfo)
+
+	/** Returns a unicode meter based on LCOV coverage. */
+	const meter = (lcov) => {
+		const per = (lcov.FNH[0] / lcov.FNF[0]) * 100
+		const sol = Math.trunc(per / 10)
+		const haf = per % 10 >= 5 ? 1 : 0
+		const emt = 10 - sol - haf
+		return [`▰`.repeat(sol), `▱`.repeat(haf), cc.dim(`▱`.repeat(emt))].join('')
+	}
+
+	/** Returns the ratio of 2 fields in LCOV data. */
+	const ratio = (lcov, l, r) => `${lcov[l]}${cc.dim('/')}${lcov[r]}`.padStart(17)
+
+	/** Based on the given LCOV data, returns the given data in a shade of green or red. */
+	const shade = (lcov, data) => (lcov.FNH / lcov.FNF > 0.6 ? cc.green : cc.red)(data)
+
+	const trtd = (lcov) =>
+		cc.dim('│ ') +
+		shade(
+			lcov,
+			lcov.SF[0]
+				.slice(-31)
+				.replace(/^[^/]*\//, '')
+				.padEnd(31, ' '),
+		) +
+		' ' +
+		shade(lcov, meter(lcov)) +
+		cc.dim(' │ ') +
+		shade(lcov, ratio(lcov, 'FNH', 'FNF')) +
+		cc.dim(' │ ') +
+		shade(lcov, ratio(lcov, 'LH', 'LF')) +
+		cc.dim(' │')
+
+	console.log(
+		[
+			[cc.dim('╭'), cc.dim('─'.repeat(44)), cc.dim('┬'), cc.dim('─'.repeat(11)), cc.dim('┬'), cc.dim('─'.repeat(11)), cc.dim('╮')].join(''),
+			[cc.dim('│'), cc.bold('Coverage') + ' '.repeat(34), cc.dim('│'), cc.bold('Functions'), cc.dim('│'), ' '.repeat(4) + cc.bold('Lines'), cc.dim('│')].join(' '),
+			[cc.dim('├'), cc.dim('─'.repeat(44)), cc.dim('┼'), cc.dim('─'.repeat(11)), cc.dim('┼'), cc.dim('─'.repeat(11)), cc.dim('┤')].join(''),
+			trtd(
+				lcovList.reduce(
+					(all, lcov) => {
+						all.FNF[0] += lcov.FNF[0]
+						all.FNH[0] += lcov.FNH[0]
+						all.LF[0] += lcov.LF[0]
+						all.LH[0] += lcov.LH[0]
+						return all
+					},
+					{ TN: [''], SF: ['All files'], FN: [], FNDA: [], FNF: [0], FNH: [0], DA: [], LH: [0], LF: [0] },
+				),
+			),
+			[cc.dim('╞'), ' '.repeat(42), cc.dim('╪'), ' '.repeat(9), cc.dim('╪'), ' '.repeat(9), cc.dim('╡')].join(' '),
+			...lcovList.map((lcov) => trtd(lcov)),
+			[cc.dim('╰'), cc.dim('─'.repeat(44)), cc.dim('┴'), cc.dim('─'.repeat(11)), cc.dim('┴'), cc.dim('─'.repeat(11)), cc.dim('╯')].join(''),
+		].join('\n'),
+	)
+})()

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "release:pack": "npm run prerelease && lerna exec -- npm pack",
     "postinstall": "run-s bootstrap",
     "test": "node .bin/test",
+    "test:coverage": "node .bin/coverage .bin/test",
     "test:lint": "node .bin/test-lint",
     "test:watch": "node .bin/test-watch"
   },


### PR DESCRIPTION
This PR adds code coverage benchmarking to the project, which will be extremely helpful in preventing regressions, identifying weakly enforced areas within our code, and will eventually be integrated into our GitHub actions to highlight coverage changes, regressions, or improvements in future PRs.

Use the `test:coverage` script to see the current project coverage. This script will generate a report viewable in the terminal, as well as write a `coverage/lcov.info` file to the project. That `lcov.info` file can then power coverage extensions for VSCode like [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) or [Code Coverage](https://marketplace.visualstudio.com/items?itemName=markis.code-coverage), allowing us to see code coverage within the source itself.

**Example usage**:
```shell
yarn test:coverage
```

**Example output**:
```
╭────────────────────────────────────────────┬───────────┬───────────╮
│ Coverage                                   │ Functions │     Lines │
├────────────────────────────────────────────┼───────────┼───────────┤
│ All files                       ▰▰▰▰▰▰▰▱▱▱ │     57/77 │   634/958 │
╞                                            ╪           ╪           ╡
│ packages/react/src/index.js     ▰▰▰▰▰▱▱▱▱▱ │     10/18 │    83/119 │
│ packages/core/src/index.js      ▰▰▰▰▰▰▰▱▱▱ │     19/27 │   324/376 │
│ core/src/defaultThemeMap.js     ▰▰▰▰▰▰▰▰▰▰ │       1/1 │     0/155 │
│ packages/core/src/CssSet.js     ▰▰▰▰▰▰▰▰▰▰ │       4/4 │     15/30 │
│ packages/core/src/Object.js     ▰▰▰▰▰▰▰▰▰▰ │       2/2 │       0/5 │
│ packages/core/src/Array.js      ▰▰▰▰▰▰▰▰▰▰ │       1/1 │       0/1 │
│ src/createGetComputedCss.js     ▰▰▰▰▰▰▰▰▰▰ │       7/7 │   162/184 │
│ src/getCustomProperties.js      ▰▰▰▰▰▰▱▱▱▱ │       2/3 │     14/18 │
│ core/src/ThemeToken.js          ▰▰▰▰▱▱▱▱▱▱ │       2/5 │      5/25 │
│ core/src/getHashString.js       ▰▰▰▰▰▰▰▰▰▰ │       2/2 │     12/14 │
│ src/getResolvedSelectors.js     ▰▰▰▰▰▰▰▰▰▰ │       4/4 │     18/21 │
│ core/src/isPossiblyUnitless.js  ▰▰▰▰▰▰▰▰▰▰ │       1/1 │       0/4 │
│ core/src/isDeclaration.js       ▰▰▰▰▰▰▰▰▰▰ │       2/2 │       1/6 │
╰────────────────────────────────────────────┴───────────┴───────────╯
```

In the terminal output, each of the files are clickable when using VSCode.

Further reading — I wrote up a lengthy description of how this code coverage is generated in NodeJS. Writing out this process was helpful in making certain the code was focused. Perhaps it could be expanded upon further to help other projects.

---

## Collecting code coverage from a NodeJS process

To generate code coverage, we first import the following NodeJS dependencies.

```js
import cp from 'child_process'
import fp from 'path'
import fs from 'fs/promises'
import os from 'os'
```

Also, many of these functions are asynchronous and therefore require an immediately invoked asynchronous function.

```js
!(async () => {
  // code with `await`...
})()
```

### Creating a directory for storing code coverage

We use the `fs.mkdtemp()` and `os.tmpdir()` functions to create a temporary directory for storing code coverage.

```js
/** Directory storing code coverage. */
const NODE_V8_COVERAGE = await fs.mkdtemp(os.tmpdir())
```

### Collecting coverage of a NodeJS process

We use the `cp.spawn()` function to run a NodeJS process with code coverage written to the `NODE_V8_COVERAGE` temporary directory.

Settle the `cp.spawn` function as a `Promise` by assigning its `close` & `error` events with `resolve` & `reject`.

```js
await new Promise((close, error) => {
  cp.spawn('node', process.argv.slice(2), {
    stdio: 'inherit',
    env: { ...process.env, NODE_V8_COVERAGE },
  })._events = { close, error }
})
```

If this code collecting coverage were in a `coverage.js` file, and the code being collected were in a `test.js` file, then usage of the code so far would look like this:

```shell
node coverage.js test.js
```

## Retrieving code coverage

We use the `fs.readFile()` function & `JSON.parse()` function to read & parse each code coverage `result`,which will be merged into one `results` array.

Finally, we use the `fs.rmdir()` function to remove the temporary directory.

```js
/** Combined coverage results */
const results = []

for (const filename of await fs.readdir(NODE_V8_COVERAGE)) {
  results.push(...JSON.parse(await fs.readFile(fp.join(NODE_V8_COVERAGE, filename), 'utf8')).result)
}

await fs.rmdir(NODE_V8_COVERAGE, { recursive: true })
```

## Transforming V8 coverage into LCOV coverage

[LCOV coverage files](http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php) are plain text files where each line uses a capitalized KEY followed by a colon (`:`) and value to represent coverage data.

```ini
TN:
SF:/Users/modulz/stitches/packages/react/src/index.js
FN:1,
FN:8,createCss
FN:117,styled
FNDA:1,
FNDA:24,createCss
FNDA:0,styled
FNF:18
FNH:10
DA:8,48
DA:9,48
LH:0
LF:108
end_of_record
```

For reference, the following `lcov` object is created to represent these keys and values.

```js
const lcov = {
  /** Test name */
  TN: [''],

  /** Source file */
  SF: [url.pathname],

  /** Line numbers for each function name. */
  FN: [],

  /** Execution count for the given function.*/
  FNDA: [],

  /** Number of functions found. */
  FNF: [0],

  /** Number of functions hit. */
  FNH: [0],

  /** Execution count for the given line. */
  DA: [],

  /** Number of collected lines with a positive execution count. */
  LH: [0],

  /** Number of collected lines. */
  LF: [0],
}
```

From this point forward, things get complicated. We filter `results` to omit any `result.url` that is a NodeJS internal or `node_modules` script. We use `fs.readFile` to read an accepted `result.url`, and the file data is split by line. The existing code coverage results are declared with position offsets, and we translate these into line and column entries. Once all of the results are transferred over, we write the results to a `coverage/lcov.info` file, and as well we display a table of coverage results directly in the terminal.