### PR TITLE
Add note about Node version in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ scope and avoid unrelated commits.
    # Build current code
    yarn build # or npm run build
    ```
+   
+   > Note: ensure your version of Node is 14 or higher to run scripts
 
    ```bash
    # Push the branch for your new feature


### PR DESCRIPTION
While following the CONTRIBUTING guide I found I was unable to run the build or test scripts on Node v12 LTS. Installing Node v14 allowed the scripts to run.