### PR TITLE
feat: insertMethod

### DIFF
--- a/packages/core/src/defaultInsertMethod.js
+++ b/packages/core/src/defaultInsertMethod.js
@@ -1,4 +1,6 @@
-export default (/** @type {boolean} */ isAppend) => {
+export default (init) => {
+	const isAppend = init.insertMethod === 'append'
+
 	let currentCssHead = null
 	let currentCssNode = null
 

--- a/packages/core/src/defaultInsertMethod.js
+++ b/packages/core/src/defaultInsertMethod.js
@@ -1,0 +1,14 @@
+export default (/** @type {boolean} */ isAppend) => {
+	let currentCssHead = null
+	let currentCssNode = null
+
+	return (/** @type {string} */ cssText) => {
+		if (typeof document === 'object') {
+			if (!currentCssHead) currentCssHead = document.head || document.documentElement
+			if (!currentCssNode) currentCssNode = document.getElementById('stitches') || assign(document.createElement('style'), { id: 'stitches' })
+			if (!currentCssNode.parentNode) currentCssHead[isAppend ? 'append' : 'prepend'](currentCssNode)
+
+			currentCssNode.textContent = cssText
+		}
+	}
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -9,6 +9,7 @@ import getHashString from './getHashString.js'
 import ThemeToken from './ThemeToken.js'
 import { $$composers } from './Symbol.js'
 import StringArray from './StringArray.js'
+import defaultInsertMethod from './defaultInsertMethod.js'
 
 /** Returns a new styled sheet and accompanying API. */
 const createCss = (init) => {
@@ -30,6 +31,8 @@ const createCss = (init) => {
 
 	/** Prefix added before all generated class names. */
 	const prefix = init.prefix || 'sx'
+
+	const insertMethod = (typeof init.insertMethod === 'function' ? init.insertMethod : defaultInsertMethod)(init.insertMethod === 'append')
 
 	const emptyClassName = '03kze'
 
@@ -59,22 +62,12 @@ const createCss = (init) => {
 	const unitedCss = new StringSet([importCss, themedCss, globalCss, styledCss])
 
 	let currentCssText = ''
-	let currentCssHead = null
-	let currentCssNode = null
 
 	const update = () => {
 		const nextUpdate = from(unitedCss).join('')
 
 		if (currentCssText !== nextUpdate) {
-			currentCssText = nextUpdate
-
-			if (typeof document === 'object') {
-				if (!currentCssHead) currentCssHead = document.head || document.documentElement
-				if (!currentCssNode) currentCssNode = document.getElementById('stitches') || assign(document.createElement('style'), { id: 'stitches' })
-				if (!currentCssNode.parentNode) currentCssHead.prepend(currentCssNode)
-
-				currentCssNode.textContent = nextUpdate
-			}
+			insertMethod((currentCssText = nextUpdate))
 		}
 	}
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -233,7 +233,7 @@ const createCss = (init) => {
 				variantInput = { ...variantInput }
 
 				for (const defaultVariantName in defaultVariants) {
-					if (variantInput[defaultVariantName] === undefined && !variantProps[defaultVariantName][variantInput[defaultVariantName]]) {
+					if (variantInput[defaultVariantName] === undefined && !Object(variantProps[defaultVariantName])[variantInput[defaultVariantName]]) {
 						variantInput[defaultVariantName] = defaultVariants[defaultVariantName]
 					}
 				}
@@ -286,8 +286,8 @@ const createCss = (init) => {
 				if (props) {
 					classNames.add(className)
 
-					for (const variant of variants) {
-						const variantClassName = variant(props, defaultVariants)
+					for (const applyVariant of variants) {
+						const variantClassName = applyVariant(props, defaultVariants)
 
 						if (variantClassName) {
 							classNames.add(variantClassName)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -32,7 +32,7 @@ const createCss = (init) => {
 	/** Prefix added before all generated class names. */
 	const prefix = init.prefix || 'sx'
 
-	const insertMethod = (typeof init.insertMethod === 'function' ? init.insertMethod : defaultInsertMethod)(init.insertMethod === 'append')
+	const insertMethod = (typeof init.insertMethod === 'function' ? init.insertMethod : defaultInsertMethod)(init)
 
 	const emptyClassName = '03kze'
 

--- a/packages/core/tests/universal-insertMethod.js
+++ b/packages/core/tests/universal-insertMethod.js
@@ -1,0 +1,76 @@
+import createCss from '../src/index.js'
+
+describe('Insert Method', () => {
+	test('default', () => {
+		const { global, toString } = createCss()
+
+		global({
+			body: {
+				margin: 0,
+			},
+		})()
+
+		expect(toString()).toBe('body{margin:0;}')
+	})
+
+	test('insertMethod: "prepend", explicit', () => {
+		const { global, toString } = createCss({
+			insertMethod: 'prepend',
+		})
+
+		global({
+			body: {
+				margin: 0,
+			},
+		})()
+
+		expect(toString()).toBe('body{margin:0;}')
+	})
+
+	test('insertMethod: "append", explicit', () => {
+		const { global, toString } = createCss({
+			insertMethod: 'append',
+		})
+
+		global({
+			body: {
+				margin: 0,
+			},
+		})()
+
+		expect(toString()).toBe('body{margin:0;}')
+	})
+
+	test('insertMethod: function, explicit', () => {
+		let didInitialize = false
+		let didInsertNode = false
+		let resultCss = ''
+		let expectCss = 'body{margin:0;}'
+
+		const { global, toString } = createCss({
+			insertMethod() {
+				didInitialize = true
+
+				return (updatedCssText) => {
+					didInsertNode = true
+
+					resultCss = updatedCssText
+				}
+			},
+		})
+
+		expect(didInitialize).toBe(true)
+		expect(didInsertNode).toBe(false)
+		expect(resultCss).toBe('')
+
+		global({
+			body: {
+				margin: 0,
+			},
+		})()
+
+		expect(didInsertNode).toBe(true)
+		expect(toString()).toBe(expectCss)
+		expect(resultCss).toBe(expectCss)
+	})
+})

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -193,9 +193,8 @@ export interface IConfig<Conditions extends TConditions = {}, Theme extends TThe
 	}
 	themeMap?: { [k in keyof ThemeMap]?: ThemeMap[k] }
 	prefix?: Prefix
-	onGlobal?: StyledSheetCallback
-	onStyled?: StyledSheetCallback
-	onThemed?: StyledSheetCallback
+	/** Determines how the CSS file is inserted to a document. */
+	insertMethod: 'append' | 'prepend' | (() => (cssText: string) => void)
 }
 type UtilConfig<Conditions, Theme, Prefix, ThemeMap> = {
 	conditions: Conditions


### PR DESCRIPTION
This PR adds the following:

- Added an `insertMethod` feature that lets users override the default DOM insertion method. By default, a stylesheet will prepend it to the beginning of the document head. Passing `append` changes the insertion method to append it to the end of the document head.

Passing an init function gives the author full control over the dom insertion, which is useful for ShadowDOM wiring up Stitches for a ShadowDOM.

```js
createCss{
  // recreates the default insertion method
  insertMethod(init) => {
    const isAppend = init.insertMethod === 'append'

    let currentCssHead = null
    let currentCssNode = null

    return (cssText) => {
      if (typeof document === 'object') {
        if (!currentCssHead) currentCssHead = document.head || document.documentElement
        if (!currentCssNode) currentCssNode = document.getElementById('stitches') || Object.assign(document.createElement('style'), { id: 'stitches' })
        if (!currentCssNode.parentNode) currentCssHead[isAppend ? 'append' : 'prepend'](currentCssNode)

        currentCssNode.textContent = cssText
      }
    }
  }
})
```

Resolves #357