### PR TITLE
fix: keyframes expressions

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -129,6 +129,8 @@ const createCss = (init) => {
 	const global = (
 		/** Styles representing global CSS. */
 		style,
+		/** Optional name */
+		name = '',
 	) => {
 		/** List of global import styles. */
 		const localImportCss = new StringSet()
@@ -144,11 +146,9 @@ const createCss = (init) => {
 			}
 		}
 
-		const expression = createComponent(create(null), 'displayName', {
-			displayName: '',
-		})
+		const expression = createComponent(create(null), 'name', { name })
 
-		return createComponent(
+		const express = createComponent(
 			() => {
 				let hasImportChanged = importCss.hasChanged
 				let hasGlobalChanged = globalCss.hasChanged
@@ -167,9 +167,15 @@ const createCss = (init) => {
 
 				return expression
 			},
-			'displayName',
-			expression,
+			'name',
+			{
+				get name() {
+					return String(express())
+				},
+			},
 		)
+
+		return express
 	}
 
 	/** Returns a function that enables the keyframe styles on the styled sheet. */
@@ -178,9 +184,9 @@ const createCss = (init) => {
 		style,
 	) => {
 		/** Unique name representing the current keyframes rule. */
-		const displayName = getHashString(prefix, style)
+		const name = getHashString(prefix, style)
 
-		return assign(global({ ['@keyframes ' + displayName]: style }), { displayName })
+		return global({ ['@keyframes ' + name]: style }, name)
 	}
 
 	const createComposer = (initStyle) => {

--- a/packages/core/tests/keyframes.js
+++ b/packages/core/tests/keyframes.js
@@ -1,0 +1,21 @@
+import createCss from '../src/index.js'
+
+describe('Keyframes', () => {
+	test('Expected behavior for the keyframes() method', () => {
+		const { keyframes, toString } = createCss()
+
+		const myKeyframes = keyframes({
+			'0%': {
+				opacity: '0',
+			},
+			'1%': {
+				opacity: '1',
+			},
+		})
+
+		expect(toString()).toBe('')
+		expect(`animation: 1s ${myKeyframes};`).toBe('animation: 1s sxk7pfs;')
+		expect(toString()).toBe('@keyframes sxk7pfs{0%{opacity:0;}1%{opacity:1;}}')
+		expect(myKeyframes.name).toBe('sxk7pfs')
+	})
+})

--- a/packages/core/tests/theme.js
+++ b/packages/core/tests/theme.js
@@ -1,0 +1,19 @@
+import createCss from '../src/index.js'
+
+describe('Theme', () => {
+	test('Expected behavior for the theme() method', () => {
+		const { theme, toString } = createCss()
+
+		const myTheme = theme('my', {
+			colors: {
+				blue: 'dodgerblue',
+			},
+		})
+
+		expect(toString()).toBe('')
+		expect(`<div class="${myTheme}">`).toBe('<div class="my">')
+		expect(toString()).toBe('.my{--colors-blue:dodgerblue;}')
+		expect(myTheme.className).toBe('my')
+		expect(myTheme.selector).toBe('.my')
+	})
+})


### PR DESCRIPTION
This PR fixes an issue with the `keyframes` method, where `@keyframes` rules were not generated correctly. This PR includes tests to ensure the regression does not return.

This PR also includes similar tests for the `theme` method.

Expected usage:

```js
const { keyframes, toString } = createCss()

const fadeIn = keyframes({
  '0%': {
    opacity: '0',
  },
  '1%': {
    opacity: '1',
  },
})

// ... later, somewhere inside or outside of stitches

`animation: 1s ${fadeIn};` // "animation: 1s sxk7pfs;"

// ... the `@keyframes` rule is now also injected
```