### PR TITLE
Fix forward ref components not rendering correctly

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -330,23 +330,19 @@ const createCss = (init) => {
 	}
 
 	const css = (...inits) => {
-		let type
 		let composers = []
 		let composer
 		let defaultVariants = create(null)
 
 		for (const init of inits) {
 			if ($$composers in Object(init)) {
-				type = init.type || type
 				for (const composer of init[$$composers]) {
 					composers.push(composer)
 					assign(defaultVariants, composer.defaultVariants)
 				}
-			} else if (init && typeof init === 'object' && !('type' in init)) {
+			} else if (init && typeof init === 'object') {
 				composers.push((composer = createComposer(init)))
 				assign(defaultVariants, composer.defaultVariants)
-			} else {
-				type = ('type' in Object(init) ? init.type : init) || type
 			}
 		}
 
@@ -411,7 +407,6 @@ const createCss = (init) => {
 					return composer.className
 				},
 				selector: composer.selector,
-				type,
 			},
 		)
 	}

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -17,7 +17,8 @@ const createCss = (init) => {
 				...args
 			) => {
 				const composition = sheet.css(...args)
-				const defaultType = composition.type || 'span'
+				const lastComposer = args.length > 1 ? args[args.length - 2] : args[args.length - 1]
+				const defaultType = Object(lastComposer).type || lastComposer || 'span'
 
 				/** Returns a React element. */
 				return Object.setPrototypeOf(

--- a/packages/react/tests/components.js
+++ b/packages/react/tests/components.js
@@ -28,4 +28,17 @@ describe('Components', () => {
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
 		expect(component.type).toBe(TextComponent)
 	})
+
+	test('The `styled` function can return an explicit forwarded React component', () => {
+		const ForwardedComponent = {
+			$$typeof: Symbol.for('react.forward_ref'),
+			render: () => 'text'
+		}
+
+		const { styled } = createCss()
+		const component = styled(ForwardedComponent)
+
+		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
+		expect(component.type).toBe(ForwardedComponent)
+	})
 })


### PR DESCRIPTION
A proposed fix for #462, moves the "type determination" concern to the react lib and out of core.

All the tests pass and it works in my medium-sized project, but I'm not 100% sure of all the implications. Feedback appreciated.