### PR TITLE
Update component processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,34 +54,63 @@
       "es6": true,
       "node": true
     },
-    "extends": [
-      "plugin:@typescript-eslint/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
+    "extends": "eslint:recommended",
+    "globals": {
+      "describe": false,
+      "expect": false,
+      "test": false
+    },
     "parserOptions": {
-      "ecmaVersion": 2020,
+      "ecmaVersion": 12,
       "sourceType": "module",
       "ecmaFeatures": {
-        "jsx": true
-      }
-    },
-    "settings": {
-      "react": {
-        "version": "detect"
+        "modules": true
       }
     },
     "rules": {
-      "@typescript-eslint/ban-types": [
+      "semi": [
         "error",
-        {
-          "extendDefaults": true,
-          "types": {
-            "{}": false
+        "never"
+      ]
+    },
+    "overrides": [
+      {
+        "files": "*.ts",
+        "env": {
+          "browser": true,
+          "es6": true,
+          "node": true
+        },
+        "extends": [
+          "plugin:@typescript-eslint/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+          "ecmaVersion": 2020,
+          "sourceType": "module",
+          "ecmaFeatures": {
+            "jsx": true
           }
+        },
+        "settings": {
+          "react": {
+            "version": "detect"
+          }
+        },
+        "rules": {
+          "@typescript-eslint/ban-types": [
+            "error",
+            {
+              "extendDefaults": true,
+              "types": {
+                "{}": false
+              }
+            }
+          ],
+          "@typescript-eslint/no-explicit-any": "off"
         }
-      ],
-      "@typescript-eslint/no-explicit-any": "off"
-    }
+      }
+    ]
   },
   "prettier": {
     "arrowParens": "always",

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -335,14 +335,18 @@ const createCss = (init) => {
 		let defaultVariants = create(null)
 
 		for (const init of inits) {
-			if ($$composers in Object(init)) {
-				for (const composer of init[$$composers]) {
-					composers.push(composer)
+			if (init === Object(init)) {
+				if ($$composers in init) {
+					for (const composer of init[$$composers]) {
+						composers.push(composer)
+
+						assign(defaultVariants, composer.defaultVariants)
+					}
+				} else {
+					composers.push((composer = createComposer(init)))
+
 					assign(defaultVariants, composer.defaultVariants)
 				}
-			} else if (init && typeof init === 'object') {
-				composers.push((composer = createComposer(init)))
-				assign(defaultVariants, composer.defaultVariants)
 			}
 		}
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,4 +1,4 @@
-import { assign, create, createComponent, defineProperties, getOwnPropertyDescriptors } from './Object.js'
+import { assign, create, createComponent } from './Object.js'
 import { from } from './Array.js'
 import { ownKeys } from './Reflect.js'
 import StringSet from './StringSet.js'

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -14,11 +14,10 @@ const createCss = (init) => {
 			/** Returns a React component. */
 			(
 				/** Type of component. */
-				...args
+				...inits
 			) => {
-				const composition = sheet.css(...args)
-				const lastComposer = args.length > 1 ? args[args.length - 2] : args[args.length - 1]
-				const defaultType = Object(lastComposer).type || lastComposer || 'span'
+				const defaultType = inits.map((init) => (Object(init).type ? init.type : init)).find((init) => init) || 'span'
+				const composition = sheet.css(...inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof)))
 
 				/** Returns a React element. */
 				return Object.setPrototypeOf(

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -30,7 +30,7 @@ const createCss = (init) => {
 							// express the component, extracting `props`, `as` & `ref`
 							const {
 								props: { as: type = defaultType, ...props },
-								...expressedProps
+								...expressedProps // eslint-disable-line no-unused-vars
 							} = composition(initProps)
 
 							/** React element. */

--- a/packages/react/tests/component.js
+++ b/packages/react/tests/component.js
@@ -32,7 +32,7 @@ describe('Components', () => {
 	test('The `styled` function can return an explicit forwarded React component', () => {
 		const ForwardedComponent = {
 			$$typeof: Symbol.for('react.forward_ref'),
-			render: () => 'text'
+			render: () => 'text',
 		}
 
 		const { styled } = createCss()

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -35,7 +35,9 @@ type ComponentInfer<T> = T extends IntrinsicElementsKeys | React.ComponentType<a
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
 type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>
 
-export type IntrinsicElement<T extends React.ElementType, B = React.ElementRef<T>> = { [k in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[k] extends B ? k : never }[keyof HTMLElementTagNameMap]
+export type IntrinsicElement<T extends React.ElementType, B = React.ElementRef<T>> = {
+	[k in keyof HTMLElementTagNameMap]: HTMLElementTagNameMap[k] extends B ? k : never
+}[keyof HTMLElementTagNameMap]
 
 export interface StitchesComponentWithAutoCompleteForJSXElements<DefaultElement extends string, Variants = {}, Conditions = {}, Theme = {}, Utils = {}, ThemeMap = {}>
 	extends React.ForwardRefExoticComponent<
@@ -180,14 +182,18 @@ export type StyledInstance<Conditions = {}, Theme extends TTheme = {}, Utils = {
 						)[]
 					}
 		),
-	): E extends string
-		? // jsx elements
-		  StitchesComponentWithAutoCompleteForJSXElements<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
-		: // if it's a stitches component we reach in and pull its type to provide better types
-		E extends { [$elm]: infer DeepStitchesComponentType }
+	): // prettier-ignore
+	E extends string
+		// jsx elements
+		? StitchesComponentWithAutoCompleteForJSXElements<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
+	// if it's a stitches component...
+	: E extends {
+		[$elm]: infer DeepStitchesComponentType
+	}
+		// reach in and pull its type to provide better types
 		? StitchesComponentWithAutoCompleteForJSXElements<DeepStitchesComponentType, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
-		: // normal react component
-		  StitchesComponentWithAutoCompleteForReactComponents<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
+	// normal react component
+	: StitchesComponentWithAutoCompleteForReactComponents<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
 } & ProxyStyledElements<Conditions, Theme, Utils, ThemeMap>
 
 export type ProxyStyledElements<Conditions = {}, Theme extends TTheme = {}, Utils = {}, ThemeMap = {}> = {
@@ -223,14 +229,18 @@ export type ProxyStyledElements<Conditions = {}, Theme extends TTheme = {}, Util
 						)[]
 					}
 		),
-	) => E extends string
-		? // jsx elements
-		  StitchesComponentWithAutoCompleteForJSXElements<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
-		: // if it's a stitches component we reach in and pull its type to provide better types
-		E extends { [$elm]: infer DeepStitchesComponentType }
+	) => // prettier-ignore
+	E extends string
+		// jsx elements
+		? StitchesComponentWithAutoCompleteForJSXElements<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
+	// if it's a stitches component...
+	: E extends {
+		[$elm]: infer DeepStitchesComponentType
+	}
+		// reach in and pull its type to provide better types
 		? StitchesComponentWithAutoCompleteForJSXElements<DeepStitchesComponentType, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils, ThemeMap>
-		: // normal react component
-		  StitchesComponentWithAutoCompleteForReactComponents<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils>
+	// normal react component
+	: StitchesComponentWithAutoCompleteForReactComponents<E, Variants & StitchesExtractVariantsStyles<E>, Conditions, Theme, Utils>
 }
 
 type ReactFactory = <Conditions extends TConditions = {}, Theme extends TTheme = {}, Utils = {}, Prefix = '', ThemeMap extends TThemeMap = CSSPropertiesToTokenScale>(


### PR DESCRIPTION
This PR changes how components are processed by `@stitches/core` and `@stitches/react`, fully removing any react component processing from `@stitches/core`, and adding it fully to `@stitches/react`.

See https://github.com/modulz/stitches/pull/467/commits/793b11e6e6ebcd2c1f936265cb01af81631b1da4 for the relevant changes.

Resolves #462