### PR TITLE
Allow utilities to accept objects as arguments

### DIFF
--- a/packages/core/src/createGetComputedCss.js
+++ b/packages/core/src/createGetComputedCss.js
@@ -8,6 +8,9 @@ const captureTokens = /([+-])?((?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?)?(\$|--)
 /** Unit-ed property name matcher. */
 const captureUnited = /(art|ding|dth|End|[Gg]ap|eft|[^e]Height|^height|op|[Rr]ight|rgin|[^b]Size|^size|tom|us)$/
 
+/** Nested selector name matcher */
+const captureSelector = /[@&#\.]/
+
 /** Returns the name of a property with tokens & camel-casing transformed. */
 const transformPropertyName = (name) => (/^\$/.test(name) ? '-' + name.replace(/\$/g, '-') : name.replace(/[A-Z]/g, (capital) => '-' + capital.toLowerCase()))
 
@@ -90,11 +93,17 @@ const createGetComputedCss = (config) => {
 				/** Whether the current style is a condition (i.e. media or supports query). */
 				const isCondition = name.charCodeAt(0) == 64
 
+				/** Whether the current style is a CSS selector */
+				const isSelector = !selectors.length || captureSelector.test(name)
+
 				dataList = isCondition && isArray(dataList) ? dataList : [dataList]
 
 				loop: for (let data of dataList) {
+					/** Whether the data is a declaration, or a styles object */
+					const isStyleDeclaration = name !== 'when' && (!isSelector || isDeclaration(data))
+
 					// process either a declaration or a nested object of styles
-					if (isDeclaration(data)) {
+					if (isStyleDeclaration) {
 						// conditionally open any unopened condition rules
 						for (const conditionRule of conditionz) {
 							if (!conditionRule[isOpen]) {

--- a/packages/core/tests/universal-nesting.js
+++ b/packages/core/tests/universal-nesting.js
@@ -90,4 +90,21 @@ describe('Nesting', () => {
 
 		expect(toString()).toBe(parentCssRule + nestingCssRule)
 	})
+
+	test('Authors can define utilities and nesting rules', () => {
+		const { css, toString } = createCss({
+			utils: {
+				article: (config) => ({ color }) => ({
+					color
+				})
+			}
+		})
+
+		css({
+			article: { color: 'red' },
+			'& article': { fontWeight: 'bold' }
+		})()
+
+		expect(toString()).toBe('.sxjls6p{color:red;}.sxjls6p article{font-weight:bold;}')
+	})
 })


### PR DESCRIPTION
Allows utilities to accept objects as arguments using the method @jonathantneal suggested in #466.

NB: this change **REQUIRES** you to use `&` for nested selectors. ie if you were doing this before:

```ts
styled('div', {
  '> *': { ... }    // this syntax works in all stitches canary versions
}
```

you now must write it as

```ts
styled('div', {
  '& > *': { ... }  // this & syntax is required by this change
}
```

Fixes: #466 