### PR TITLE
Feature: Updated insertion method

### DIFF
--- a/.bin/build-package.js
+++ b/.bin/build-package.js
@@ -26,7 +26,7 @@ const variants = {
 		transform(code, exports) {
 			const iifeExports = []
 			for (const name in exports) iifeExports.push(`${name}:${exports[name]}`)
-			return `${code}globalThis.stitches={${iifeExports.join(',')}}`
+			return `(()=>{${code}globalThis.stitches={${iifeExports.join(',')}}})()`
 		},
 	},
 }


### PR DESCRIPTION
This PR changes the default insertion method to reduce the likelihood of style changes.

- During a push of styles, the update to `<style />` is delayed by one frame, tho _only_ if the tag already has content.
- Each push of new changes will restart the delay like a debouncer.
- If a delay to write modified CSS is fulfilled, then `<style />` will be updated.