### PR TITLE
Polyfill prefixed values

### DIFF
--- a/packages/core/tests/universal-polyfill-prefixed-values.js
+++ b/packages/core/tests/universal-polyfill-prefixed-values.js
@@ -1,0 +1,33 @@
+import { createCss } from '../src/index.js'
+
+describe('Polyfill prefixed values', () => {
+	test('width:stretch', () => {
+		const { global, toString } = createCss()
+
+		global({
+			'.gro': {
+				width: 'stretch',
+			},
+		})()
+
+		// prettier-ignore
+		expect(toString()).toBe(
+			'.gro{width:-moz-available;width:-webkit-fill-available;}'
+		)
+	})
+
+	test('width:fit-content', () => {
+		const { global, toString } = createCss()
+
+		global({
+			'.fit': {
+				width: 'fit-content',
+			},
+		})()
+
+		// prettier-ignore
+		expect(toString()).toBe(
+			'.fit{width:-moz-fit-content;width:fit-content;}'
+		)
+	})
+})


### PR DESCRIPTION
This PR adds the ability to automatically prefix the [`fit-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content) and [`stretch`](https://www.w3.org/TR/2020/WD-css-sizing-4-20201020/#sizing-values) values on css size properties in CSS.

**Before**:
```js
{
  '.gro': {
    width: 'stretch'
  }
}
```

**After**:
```css
.gro{width:-moz-available;width:-webkit-fill-available;}
```

**Before**:
```js
{
  '.fit': {
    width: 'fit-content'
  }
}
```

**After**:
```css
.fit{width:-moz-fit-content;width:fit-content;}
```
