### PR TITLE
0.1.1

### DIFF
--- a/.bin/build-package.js
+++ b/.bin/build-package.js
@@ -26,7 +26,7 @@ const variants = {
 		transform(code, exports) {
 			const iifeExports = []
 			for (const name in exports) iifeExports.push(`${name}:${exports[name]}`)
-			return `${code}globalThis.stitches={${iifeExports.join(',')}}`
+			return `(()=>{${code}globalThis.stitches={${iifeExports.join(',')}}})()`
 		},
 	},
 }

--- a/packages/core/src/createStringify.js
+++ b/packages/core/src/createStringify.js
@@ -34,8 +34,6 @@ const polys = {
 export const createStringify = (config) => {
 	const { media, themeMap, utils } = config
 
-	let lastPolyFunc
-	let lastPolyData
 	let lastRegxName
 	let lastRegxData
 	let lastUtilFunc
@@ -47,31 +45,25 @@ export const createStringify = (config) => {
 			const camelName = firstChar === 64 ? name : toCamelCase(name)
 			const kebabName = firstChar === 64 ? name : toKebabCase(name)
 
-			// run utilities that match the raw left-hand of the CSS rule or declaration
-			if (typeof utils[name] === 'function' && (utils[name] != lastUtilFunc || data != lastUtilData)) {
-				lastUtilFunc = utils[name]
-				lastUtilData = data
+			if (typeof utils[name] === 'function') {
+				// run utilities that match the raw left-hand of the CSS rule or declaration
+				if (utils[name] != lastUtilFunc || data != lastUtilData) {
+					lastUtilFunc = utils[name]
+					lastUtilData = data
 
-				return lastUtilFunc(config)(lastUtilData)
+					return lastUtilFunc(config)(lastUtilData)
+				}
+			} else if (typeof polys[camelName] === 'function') {
+				// run polyfills that match the camel-case-left hand of the CSS declaration
+				if (polys[camelName] != lastUtilFunc || data != lastUtilData) {
+					lastUtilFunc = polys[camelName]
+					lastUtilData = data
+
+					return lastUtilFunc(lastUtilData)
+				}
 			}
 
 			lastUtilData = data
-
-			// run polyfills that match the camel-case-left hand of the CSS declaration
-			if (typeof polys[camelName] === 'function' && (polys[camelName] != lastPolyFunc || data != lastPolyData)) {
-				lastPolyFunc = polys[camelName]
-				lastPolyData = data
-
-				return lastPolyFunc(lastPolyData)
-			}
-
-			// run polyfills that match the camel-case-left hand of the CSS declaration
-			if (typeof polys[camelName] === 'function' && (polys[camelName] != lastPolyFunc || data != lastPolyData)) {
-				lastPolyFunc = polys[camelName]
-				lastPolyData = data
-
-				return lastPolyFunc(lastPolyData)
-			}
 
 			if (lastRegxName != camelName && lastRegxData != data && /^((min|max)?((Block|Inline)Size|Height|Width)|height|width)$/.test(camelName)) {
 				lastRegxName = camelName

--- a/packages/core/src/defaultThemeMap.js
+++ b/packages/core/src/defaultThemeMap.js
@@ -100,6 +100,7 @@ const defaultThemeMap = {
 	color: colors,
 	columnRuleColor: colors,
 	fill: colors,
+	outline: colors,
 	outlineColor: colors,
 	stroke: colors,
 	textDecorationColor: colors,

--- a/packages/core/tests/universal-polyfill-prefixed-values.js
+++ b/packages/core/tests/universal-polyfill-prefixed-values.js
@@ -1,0 +1,33 @@
+import { createCss } from '../src/index.js'
+
+describe('Polyfill prefixed values', () => {
+	test('width:stretch', () => {
+		const { global, toString } = createCss()
+
+		global({
+			'.gro': {
+				width: 'stretch',
+			},
+		})()
+
+		// prettier-ignore
+		expect(toString()).toBe(
+			'.gro{width:-moz-available;width:-webkit-fill-available;}'
+		)
+	})
+
+	test('width:fit-content', () => {
+		const { global, toString } = createCss()
+
+		global({
+			'.fit': {
+				width: 'fit-content',
+			},
+		})()
+
+		// prettier-ignore
+		expect(toString()).toBe(
+			'.fit{width:-moz-fit-content;width:fit-content;}'
+		)
+	})
+})


### PR DESCRIPTION
- Polyfills the vendor-prefixed sizing values `stretch` and `fit-content`.
- Maps the `outline` property to the `color` theme token.
- Run utilities for properties instead of polyfills, instead of running them beforehand.
- Update the DOM even more sparingly.