### PR TITLE
Fix: Do not add an undefined className to a DOM Element

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -384,7 +384,7 @@ const createCss = (init) => {
 					}
 				}
 
-				if ('className' in props) {
+				if ('className' in props && props.className) {
 					String(props.className).split(/\s+/).forEach(classNames.add, classNames)
 				}
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -384,8 +384,8 @@ const createCss = (init) => {
 					}
 				}
 
-				if ('className' in props && props.className) {
-					String(props.className).split(/\s+/).forEach(classNames.add, classNames)
+				if (typeof props.className === 'string') {
+					props.className.split(/\s+/).forEach(classNames.add, classNames)
 				}
 
 				const classNameSetArray = from(classNames)

--- a/packages/react/tests/component-className-prop.js
+++ b/packages/react/tests/component-className-prop.js
@@ -1,0 +1,33 @@
+import createCss from '../src/index.js'
+
+describe('className prop', () => {
+	test('Renders a DOM Element with a class matching the className prop', () => {
+		const { styled } = createCss()
+
+		const component = styled('div')
+		const className = 'myClassName';
+		const expression = component.render({ className })
+
+		expect(expression.props.className).toBe(className)
+	})
+
+	test('Renders a DOM Element with multiple classes passed as className', () => {
+		const { styled } = createCss()
+
+		const component = styled('div')
+		const className = 'myClassName1 myClassName2 myClassName3';
+		const expression = component.render({ className })
+
+		expect(expression.props.className).toBe(className)
+	})
+
+	test('Renders a DOM Element withoup adding an undefined class', () => {
+		const { styled } = createCss()
+
+		const component = styled('div')
+		const className = undefined;
+		const expression = component.render({ className })
+
+		expect(expression.props.className).toNotBe('undefined')
+	})
+})


### PR DESCRIPTION
Styled elements with `className={undefined}` do not add a class "undefined" to the DOM element anymore.

- resolves #537