### PR TITLE
Fix: made it possible to use ThemeToken instances as css property values

### DIFF
--- a/packages/stringify/src/index.js
+++ b/packages/stringify/src/index.js
@@ -32,7 +32,8 @@ export const stringify = (
 				}
 
 				const isAtRuleLike = name.charCodeAt(0) === 64
-				const isObjectLike = data === Object(data) && !('length' in data)
+				const isThemeToken = data.constructor.name === 'ThemeToken'
+				const isObjectLike = data === Object(data) && !('length' in data) && !isThemeToken
 
 				if (isObjectLike) {
 					if (used.has(selectors)) {

--- a/packages/stringify/tests/index.js
+++ b/packages/stringify/tests/index.js
@@ -121,4 +121,23 @@ describe('stringify()', () => {
 			'}',
 		)
 	})
+
+	test('stringify() generates CSS with direct use of ThemeToken instances', () => {
+		class ThemeToken {
+			toString() {
+				return 'var(--some-token)'
+			}
+		}
+
+		const redToken = new ThemeToken()
+
+		expect(
+			stringify({
+				color: redToken,
+			}),
+		).toEqual(
+			// prettier-ignore
+			'color:var(--some-token);',
+		)
+	})
 })


### PR DESCRIPTION
The recommended way to use tokens is nice, but it's not refactoring friendly. If we make it possible to use ThemeToken instances as css prop values, we can still use tokens in a nice way and refactoring works better.

```typescript
import { createCss } from "@stitches/react"

const { styled, theme } = createCss({
  theme: {
    colors: {
      coral: "#f5533d"
    }
  }
})

const Root = styled('div', {
  color: theme.colors.coral
})
```