### PR TITLE
Fix: Add default className when initialized without CSS prop

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -16,7 +16,9 @@ const createCss = (init) => {
 			...inits
 		) => {
 			const defaultType = inits.map((init) => (Object(init).type ? init.type : init)).find((init) => init) || 'span'
-			const composition = sheet.css(...inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof)))
+			const initsFiltered = inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof));
+			const initWithoutStyles = String(defaultType) === defaultType && !initsFiltered.length
+			const composition = sheet.css(...initsFiltered, initWithoutStyles && {})
 
 			/** Returns a React element. */
 			return Object.setPrototypeOf(

--- a/packages/react/tests/component-css-prop.js
+++ b/packages/react/tests/component-css-prop.js
@@ -53,4 +53,16 @@ describe('React Component with CSS prop', () => {
 			'}',
 		)
 	})
+
+	test('Authors can create a component witout CSS prop', () => {
+		const { styled, toString } = createCss()
+
+		const expression = styled('button').render()
+
+		expect(expression.props).toEqual({
+			className: 'sx03kze'
+		})
+	
+		expect(toString()).toBe('')
+	})
 })


### PR DESCRIPTION
When creating a Stitches component without a CSS prop, it is now created with the default className `sx03kze`.

Not adding the default class to the DOM element can lead to confusion. For example when targetting the component with a selector in the styles of a parent.

```
const Label = styled('span');

const Button = styled('button', {
  [`& ${Label}`]: {
    color: 'lavenderblush'
  }
});
```

- resolves #533