### PR TITLE
Support theme token values

### DIFF
--- a/packages/core/src/Array.js
+++ b/packages/core/src/Array.js
@@ -1,1 +1,0 @@
-export const { from, isArray } = Array

--- a/packages/core/src/StringSet.js
+++ b/packages/core/src/StringSet.js
@@ -1,5 +1,5 @@
 import { toPrimitive } from './Symbol.js'
-import { from } from './Array.js'
+import { from } from '../../stringify/src/Array.js'
 
 export default class StringSet extends Set {
 	toString() {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,6 +1,6 @@
 import { assign, create, createComponent } from './Object.js'
 import { createStringify } from './createStringify.js'
-import { from } from './Array.js'
+import { from } from '../../stringify/src/Array.js'
 import { ownKeys } from './Reflect.js'
 import StringSet from './StringSet.js'
 import defaultThemeMap from './defaultThemeMap.js'

--- a/packages/core/tests/global-atrules.js
+++ b/packages/core/tests/global-atrules.js
@@ -51,9 +51,15 @@ describe('Support @font-face', () => {
 		})()
 
 		expect(toString()).toBe(
-			`@font-face{font-family:system-ui;font-style:normal;font-weight:400;src:local(".SFNS-Regular"),local(".SFNSText-Regular"),local(".HelveticaNeueDeskInterface-Regular"),local(".LucidaGrandeUI"),local("Segoe UI"),local("Ubuntu"),local("Roboto-Regular"),local("DroidSans"),local("Tahoma");}`,
+			`@font-face{` +
+				`font-family:system-ui;` +
+				`font-style:normal;` +
+				`font-weight:400;` +
+				`src:local(".SFNS-Regular"),local(".SFNSText-Regular"),local(".HelveticaNeueDeskInterface-Regular"),local(".LucidaGrandeUI"),local("Segoe UI"),local("Ubuntu"),local("Roboto-Regular"),local("DroidSans"),local("Tahoma");` +
+			`}`,
 		)
 	})
+
 	test('Authors can define multiple @font-face rules', () => {
 		const { global, toString } = createCss({})
 
@@ -94,9 +100,21 @@ describe('Support @font-face', () => {
 			],
 		})()
 
-		const cssFontFaceRule1 = `@font-face{font-family:system-ui;font-style:normal;font-weight:400;src:local(".SFNS-Regular"),local(".SFNSText-Regular"),local(".HelveticaNeueDeskInterface-Regular"),local(".LucidaGrandeUI"),local("Segoe UI"),local("Ubuntu"),local("Roboto-Regular"),local("DroidSans"),local("Tahoma");}`
-		const cssFontFaceRule2 = `@font-face{font-family:system-ui;font-style:normal;font-weight:400;src:local(".SFNS-Italic"),local(".SFNSText-Italic"),local(".HelveticaNeueDeskInterface-Italic"),local(".LucidaGrandeUI"),local("Segoe UI Italic"),local("Ubuntu Italic"),local("Roboto-Italic"),local("DroidSans"),local("Tahoma");}`
 
-		expect(toString()).toBe(cssFontFaceRule1 + cssFontFaceRule2)
+		expect(toString()).toBe(
+			`@font-face{` +
+				`font-family:system-ui;` +
+				`font-style:normal;` +
+				`font-weight:400;` +
+				`src:local(".SFNS-Regular"),local(".SFNSText-Regular"),local(".HelveticaNeueDeskInterface-Regular"),local(".LucidaGrandeUI"),local("Segoe UI"),local("Ubuntu"),local("Roboto-Regular"),local("DroidSans"),local("Tahoma");` +
+			`}` +
+
+			`@font-face{` +
+				`font-family:system-ui;` +
+				`font-style:normal;` +
+				`font-weight:400;` +
+				`src:local(".SFNS-Italic"),local(".SFNSText-Italic"),local(".HelveticaNeueDeskInterface-Italic"),local(".LucidaGrandeUI"),local("Segoe UI Italic"),local("Ubuntu Italic"),local("Roboto-Italic"),local("DroidSans"),local("Tahoma");` +
+			`}`
+		)
 	})
-})
+}) // prettier-ignore

--- a/packages/core/tests/universal-tokens.js
+++ b/packages/core/tests/universal-tokens.js
@@ -17,7 +17,10 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--colors-red:tomato;}` + `article{color:var(--colors-red);}`)
+			expect(toString()).toBe(
+				`:root{--colors-red:tomato;}` +
+				`article{color:var(--colors-red);}`
+			)
 		}
 
 		{
@@ -35,7 +38,10 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--shadows-red:tomato;}` + `article{box-shadow:0 0 0 1px var(--shadows-red);}`)
+			expect(toString()).toBe(
+				`:root{--shadows-red:tomato;}` +
+				`article{box-shadow:0 0 0 1px var(--shadows-red);}`
+			)
 		}
 	})
 
@@ -55,7 +61,10 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--colors-red:tomato;}` + `article{box-shadow:0 0 0 1px var(--colors-red);}`)
+			expect(toString()).toBe(
+				`:root{--colors-red:tomato;}` +
+				`article{box-shadow:0 0 0 1px var(--colors-red);}`
+			)
 		}
 
 		{
@@ -73,7 +82,10 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--colors-red:tomato;}` + `article{box-shadow:0 0 0 1px var(--colors-red);}`)
+			expect(toString()).toBe(
+				`:root{--colors-red:tomato;}` +
+				`article{box-shadow:0 0 0 1px var(--colors-red);}`
+			)
 		}
 	})
 
@@ -95,7 +107,10 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--space-sp1:100px;--space-sp2:200px;}` + `article{margin-left:calc(var(--space-sp1)*-1);margin-top:calc(var(--space-sp2)*-1);}`)
+			expect(toString()).toBe(
+				`:root{--space-sp1:100px;--space-sp2:200px;}` +
+				`article{margin-left:calc(var(--space-sp1)*-1);margin-top:calc(var(--space-sp2)*-1);}`
+			)
 		}
 
 		{
@@ -116,7 +131,62 @@ describe('Tokens', () => {
 				},
 			})()
 
-			expect(toString()).toBe(`:root{--sizes-sp1:10px;--sizes-sp2:20px;--sizes-sp3:30px;}` + `article{margin-left:calc(var(--sizes-sp1)*-1);width:var(--sizes-sp1);}`)
+			expect(toString()).toBe(
+				`:root{--sizes-sp1:10px;--sizes-sp2:20px;--sizes-sp3:30px;}` +
+				`article{margin-left:calc(var(--sizes-sp1)*-1);width:var(--sizes-sp1);}`
+			)
 		}
 	})
-})
+
+	test('Authors can use tokens from the global theme object', () => {
+		const { global, theme, toString } = createCss({
+			theme: {
+				space: {
+					sp1: '100px',
+					sp2: '200px',
+				},
+			},
+		})
+
+		global({
+			article: {
+				marginLeft: theme.space.sp1,
+				marginTop: theme.space.sp2,
+			},
+		})()
+
+		expect(toString()).toBe(
+			`:root{--space-sp1:100px;--space-sp2:200px;}` +
+			`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2);}`,
+		)
+	})
+
+	test('Authors can use tokens from a new theme object', () => {
+		const { global, theme, toString } = createCss()
+
+		const mytheme = theme('my-theme', {
+			space: {
+				sp1: '100px',
+				sp2: '200px',
+			},
+		})
+
+		global({
+			article: {
+				marginLeft: mytheme.space.sp1,
+				marginTop: mytheme.space.sp2,
+			},
+		})()
+
+		expect(toString()).toBe(
+			`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2);}`,
+		)
+
+		mytheme.className
+
+		expect(toString()).toBe(
+			`.my-theme{--space-sp1:100px;--space-sp2:200px;}` +
+			`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2);}`,
+		)
+	})
+}) // prettier-ignore

--- a/packages/stringify/src/Array.js
+++ b/packages/stringify/src/Array.js
@@ -1,0 +1,2 @@
+export const { isArray } = Array
+export const { from } = Array


### PR DESCRIPTION
This PR updates many stitches internals to allow theme tokens to be used as css property values.

Example usage:

```js
const { global, theme, toString } = createCss({
  theme: {
    space: {
      sp1: '100px',
      sp2: '200px',
    },
  },
})

global({
  article: {
    marginLeft: theme.space.sp1,
    marginTop: theme.space.sp2,
  },
})()

expect(toString()).toBe(
  `:root{--space-sp1:100px;--space-sp2:200px;}` +
  `article{margin-left:var(--space-sp1);margin-top:var(--space-sp2);}`,
)
```

```js
const { global, theme, toString } = createCss()

const mytheme = theme('my-theme', {
  space: {
    sp1: '100px',
    sp2: '200px',
  },
})

global({
  article: {
    marginLeft: mytheme.space.sp1,
    marginTop: mytheme.space.sp2,
  },
})()
```

Resolves #540.
