### PR TITLE
Force components to include at least one composer

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -334,8 +334,8 @@ const createCss = (init) => {
 	}
 
 	const css = (...inits) => {
-		let composers = []
 		let composer
+		let composers = []
 		let defaultVariants = create(null)
 
 		for (const init of inits) {
@@ -354,7 +354,9 @@ const createCss = (init) => {
 			}
 		}
 
-		composer = composer || createComposer({})
+		if (!composer) {
+			composers.push((composer = createComposer({})))
+		}
 
 		return createComponent(
 			(initProps) => {

--- a/packages/core/tests/component-composition.js
+++ b/packages/core/tests/component-composition.js
@@ -1,6 +1,14 @@
 import { createCss } from '../src/index.js'
 
 describe('Composition', () => {
+	test('Renders an empty component', () => {
+		const { css, toString } = createCss()
+		const generic = css()
+
+		expect(generic().props).toEqual({ className: 'sx03kze' })
+		expect(toString()).toBe('')
+	})
+
 	test('Renders a component as the final composition by default', () => {
 		const { css, toString } = createCss()
 		const red = css({ color: 'red' })

--- a/packages/react/tests/component-className-prop.js
+++ b/packages/react/tests/component-className-prop.js
@@ -5,27 +5,27 @@ describe('className prop', () => {
 		const { styled } = createCss()
 
 		const component = styled('div')
-		const className = 'myClassName';
+		const className = 'myClassName'
 		const expression = component.render({ className })
 
-		expect(expression.props.className).toBe(className)
+		expect(expression.props.className).toBe('sx03kze ' + className)
 	})
 
 	test('Renders a DOM Element with multiple classes passed as className', () => {
 		const { styled } = createCss()
 
 		const component = styled('div')
-		const className = 'myClassName1 myClassName2 myClassName3';
+		const className = 'myClassName1 myClassName2 myClassName3'
 		const expression = component.render({ className })
 
-		expect(expression.props.className).toBe(className)
+		expect(expression.props.className).toBe('sx03kze ' + className)
 	})
 
 	test('Renders a DOM Element withoup adding an undefined class', () => {
 		const { styled } = createCss()
 
 		const component = styled('div')
-		const className = undefined;
+		const className = undefined
 		const expression = component.render({ className })
 
 		expect(expression.props.className).toNotBe('undefined')

--- a/packages/react/tests/component-composition.js
+++ b/packages/react/tests/component-composition.js
@@ -1,6 +1,14 @@
 import createCss from '../src/index.js'
 
 describe('Composition', () => {
+	test('Renders an empty component', () => {
+		const { styled, toString } = createCss()
+		const generic = styled()
+
+		expect(generic.render().props).toEqual({ className: 'sx03kze' })
+		expect(toString()).toBe('')
+	})
+
 	test('Renders a component as the final composition by default', () => {
 		const { styled, toString } = createCss()
 		const red = styled({ color: 'red' })


### PR DESCRIPTION
This PR updates components so that they will always include their forced composer if none exist.

Resolves #533
Resolves #542