### PR TITLE
fix: pass `initConfig` to `insertionMethod`

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -34,7 +34,7 @@ const createCss = (initConfig) => {
 	/** Prefix added before all generated class names. */
 	const prefix = config.prefix = initConfig.prefix || 'sx'
 
-	const insertionMethod = (typeof initConfig.insertionMethod === 'function' ? initConfig.insertionMethod : defaultInsertionMethod)(config)
+	const insertionMethod = (typeof initConfig.insertionMethod === 'function' ? initConfig.insertionMethod : defaultInsertionMethod)(initConfig)
 
 	const emptyClassName = '03kze'
 


### PR DESCRIPTION
`defaultInsertionMethod` checks for `insertionMethod` string to determine if it should append or prepend styles in the head: https://github.com/modulz/stitches/blob/e0a99d32005657a839d94784dab795413eb50eac/packages/core/src/defaultInsertionMethod.js#L12. However the `config` object doesn't have the `insertionMethod` prop, so it's impossible to overwrite the default `prepend` behavior with `append`. The solution is to pass `initConfig`.