### PR TITLE
Hydrated configuration

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,9 +12,9 @@ import defaultInsertionMethod from './defaultInsertionMethod.js'
 
 /** Returns a new styled sheet and accompanying API. */
 const createCss = (initConfig) => {
-	const config = {}
+	initConfig = typeof initConfig === 'object' && initConfig || {}
 
-	initConfig = config.config = typeof initConfig === 'object' && initConfig || {}
+	const config = {}
 
 	/** Named media queries. */
 	config.media = assign({ initial: 'all' }, initConfig.media)
@@ -29,13 +29,18 @@ const createCss = (initConfig) => {
 	config.utils = typeof initConfig.utils === 'object' && initConfig.utils || {}
 
 	/** Names of variants passed through to props. */
-	const passThru = new Set([].concat(initConfig.passthru || ['as', 'className']))
+	const passThru = new Set(initConfig.passthru ? [ ...initConfig.passthru, 'as', 'className' ] : ['as', 'className'])
 
 	/** Prefix added before all generated class names. */
 	const prefix = config.prefix = initConfig.prefix || 'sx'
 
-	const insertionMethod = (typeof initConfig.insertionMethod === 'function' ? initConfig.insertionMethod : defaultInsertionMethod)(config)
+	/** Keyword or function used to determine how DOM styles are updated. */
+	config.insertionMethod = initConfig.insertionMethod || 'prepend'
 
+	/** Function used to update DOM styles. */
+	const insertionMethod = (typeof config.insertionMethod === 'function' ? config.insertionMethod : defaultInsertionMethod)(config)
+
+	/** Class name for compositions without any style. */
 	const emptyClassName = '03kze'
 
 	/** Returns a string of unnested CSS from an object of nestable CSS. */

--- a/packages/core/tests/universal-insertionMethod.js
+++ b/packages/core/tests/universal-insertionMethod.js
@@ -1,6 +1,6 @@
 import { createCss } from '../src/index.js'
 
-describe('Insert Method', () => {
+describe('Insertion Method', () => {
 	test('default', () => {
 		const { global, toString } = createCss()
 
@@ -14,7 +14,7 @@ describe('Insert Method', () => {
 	})
 
 	test('insertionMethod: "prepend", explicit', () => {
-		const { global, toString } = createCss({
+		const { config, global, toString } = createCss({
 			insertionMethod: 'prepend',
 		})
 
@@ -25,10 +25,12 @@ describe('Insert Method', () => {
 		})()
 
 		expect(toString()).toBe('body{margin:0;}')
+
+		expect(config.insertionMethod).toBe('prepend')
 	})
 
 	test('insertionMethod: "append", explicit', () => {
-		const { global, toString } = createCss({
+		const { config, global, toString } = createCss({
 			insertionMethod: 'append',
 		})
 
@@ -39,6 +41,8 @@ describe('Insert Method', () => {
 		})()
 
 		expect(toString()).toBe('body{margin:0;}')
+
+		expect(config.insertionMethod).toBe('append')
 	})
 
 	test('insertionMethod: function, explicit', () => {
@@ -47,17 +51,17 @@ describe('Insert Method', () => {
 		let resultCss = ''
 		let expectCss = 'body{margin:0;}'
 
-		const { global, toString } = createCss({
-			insertionMethod() {
-				didInitialize = true
+		const insertionMethod = () => {
+			didInitialize = true
 
-				return (updatedCssText) => {
-					didInsertNode = true
+			return (updatedCssText) => {
+				didInsertNode = true
 
-					resultCss = updatedCssText
-				}
-			},
-		})
+				resultCss = updatedCssText
+			}
+		}
+
+		const { config, global, toString } = createCss({ insertionMethod })
 
 		expect(didInitialize).toBe(true)
 		expect(didInsertNode).toBe(false)
@@ -72,5 +76,7 @@ describe('Insert Method', () => {
 		expect(didInsertNode).toBe(true)
 		expect(toString()).toBe(expectCss)
 		expect(resultCss).toBe(expectCss)
+
+		expect(config.insertionMethod).toBe(insertionMethod)
 	})
 })


### PR DESCRIPTION
This PR changes how the configuration object is hydrated, so that the `config` object returned by `createCss` is always the newly hydrated version.

This PR also resolves a regression where `insertionMethod` was not receiving the correct configuration, and includes tests to ensure another regression is unlikely.

Resolves #550