### PR TITLE
fix: support non-undefined className prop values

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -399,8 +399,8 @@ const createCss = (initConfig) => {
 					}
 				}
 
-				if (typeof props.className === 'string') {
-					props.className.split(/\s+/).forEach(classNames.add, classNames)
+				if (props.className !== undefined) {
+					String(props.className).split(/\s+/).forEach(classNames.add, classNames)
 				}
 
 				const classNameSetArray = from(classNames)

--- a/packages/react/tests/issue-555.js
+++ b/packages/react/tests/issue-555.js
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import * as renderer from 'react-test-renderer'
+import createCss from '../src/index.js'
+
+let RenderOf = (...args) => {
+	let Rendered
+
+	void renderer.act(() => {
+		Rendered = renderer.create(React.createElement(...args))
+	})
+
+	const json = Rendered.toJSON()
+	const { props } = json
+
+	for (const prop in props) {
+		const value = props[prop]
+
+		// serialize objects as they might appear in a render
+		if (typeof value === 'object' && value !== null && value[Symbol.toPrimitive]) {
+			props[prop] = value[Symbol.toPrimitive]()
+		}
+	}
+
+	return json
+}
+
+describe('Issue #555', () => {
+	test('an element accepts styles via className prop', () => {
+		const { css, toString } = createCss()
+
+		const el = css({ color: "dodgerblue" })
+
+		expect(
+			RenderOf('div', { className: el() })
+		).toEqual({
+			type: 'div',
+			props: {
+				className: 'sxr9r9e',
+			},
+			children: null,
+		})
+
+		expect(toString()).toBe(`.sxr9r9e{color:dodgerblue;}`)
+	})
+	test('an element accepts styles via className prop', () => {
+		const { css, styled, toString } = createCss()
+
+		const el = css({ color: "dodgerblue" })
+		const Box = styled('div', {})
+
+		expect(
+			RenderOf(Box, { className: el() })
+		).toEqual({
+			type: 'div',
+			props: {
+				className: 'sx03kze sxr9r9e',
+			},
+			children: null,
+		})
+
+		expect(toString()).toBe(`.sxr9r9e{color:dodgerblue;}`)
+	})
+}) // prettier-ignore


### PR DESCRIPTION
This PR fixes an issue where non-string `className` prop values were ignored.

Resolves #555