### PR TITLE
Add `key: null` to React element object

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -33,7 +33,7 @@ const createCss = (init) => {
 						} = composition(initProps)
 
 						/** React element. */
-						return { constructor: undefined, $$typeof: $$typeofElement, props, ref, type, __v: 0 }
+						return { constructor: undefined, $$typeof: $$typeofElement, props, ref, type, key: null, __v: 0 }
 					},
 					$$typeof: $$typeofForward,
 					[$$composers]: composition[$$composers],


### PR DESCRIPTION
This will prevent React from thinking the key value is `undefined`, which I believe is a valid key (in React dev tools it show up as `key="undefined"` on every `styled` component).