### PR TITLE
Feature: check SSR text before changes

### DIFF
--- a/packages/core/src/defaultInsertionMethod.js
+++ b/packages/core/src/defaultInsertionMethod.js
@@ -1,50 +1,21 @@
 import { assign } from './Object.js'
 
 export default (init) => {
-	let isSsrCssRemoved = false
-
-	let currentCssHead
-	let currentCssNode
-	let currentSsrText
-	let currentHotText
-	let visibilityWait
-
 	const insertionMethod = init.insertionMethod === 'append' ? 'append' : 'prepend'
 
+	const hasDocument = typeof document === 'object'
+
+	const currentCssHead = hasDocument ? document.head || document.documentElement : null
+
+	const currentCssNode = hasDocument ? document.getElementById('stitches') || assign(document.createElement('style'), { id: 'stitches' }) : { isConnected: true, firstChild: { data: '' } }
+
+	const currentCssText = hasDocument ? currentCssNode.appendChild(new Text()) : { data: '' }
+
+	init.ssrText = currentCssNode.firstChild.data
+
 	return (/** @type {string} */ cssText) => {
-		// only update if the document is available
-		if (typeof document === 'object') {
-			// use the document head or the document root
-			if (!currentCssHead) currentCssHead = document.head || document.documentElement
+		if (!currentCssNode.isConnected) currentCssHead[insertionMethod](currentCssNode)
 
-			// use the existing stitches style element, otherwise create one
-			if (!currentCssNode) currentCssNode = document.getElementById('stitches') || assign(document.createElement('style'), { id: 'stitches', textContent: cssText })
-
-			// use the prerendered stitches style text, otherwise create one outside of the document
-			if (!currentSsrText) {
-				currentSsrText = currentCssNode.firstChild || new Text()
-
-				isSsrCssRemoved = !currentSsrText.data
-			}
-
-			// use a new stitches style text for hot-loaded styles
-			if (!currentHotText) currentHotText = currentCssNode.insertBefore(new Text(), currentSsrText)
-
-			// attach the stitches style element to the document if it not already connected
-			if (!currentCssNode.isConnected) currentCssHead[insertionMethod](currentCssNode)
-
-			currentHotText.data = cssText
-
-			// remove the prerendered stiches style text once the document is visible
-			if (!isSsrCssRemoved && cssText) {
-				clearTimeout(visibilityWait)
-
-				visibilityWait = setTimeout(() => {
-					currentSsrText.remove()
-
-					isSsrCssRemoved = true
-				}, 250)
-			}
-		}
+		currentCssText.data = cssText
 	}
 }


### PR DESCRIPTION
This PR changes how Stitches hydrates `<style>` tags, so that SSR text is never removed from a sheet, and so that pre-existing styles are never added to the stylesheet. This change also removes the debouncer, which had introduced delayed renderings.

Resolves #523