### PR TITLE
Fix: Ignore the default prefix on tokens

### DIFF
--- a/packages/core/src/createStringify.js
+++ b/packages/core/src/createStringify.js
@@ -40,6 +40,15 @@ export const createStringify = (config) => {
 
 	const memo = {}
 
+	// TODO: PLEASE REMOVE THIS
+	//       This separates "prefixing" from "token prefixing". At this time,
+	//       Stitches assigns a default "prefix", which is required to generate
+	//       valid CSS classes. Authors don’t mind this, but they do mind when
+	//       the default prefix gets assigned to tokens. We are solving this
+	//       another way — the right way — but as a "patch" this code creates
+	//       a forked prefix just for tokens, ignoring the default "sx" prefix.
+	const tokenPrefix = config.prefix === 'sx' ? '' : '--' + config.prefix
+
 	return (css) => {
 		const jss = toJson(css)
 
@@ -96,7 +105,7 @@ export const createStringify = (config) => {
 						)
 					// whether the first character is a "$"
 					: firstChar === 36
-						? '--' + config.prefix + name.replace(/\$/g, '-')
+						? tokenPrefix + name.replace(/\$/g, '-')
 					: name
 				)
 

--- a/packages/core/tests/issue-999.js
+++ b/packages/core/tests/issue-999.js
@@ -2,7 +2,7 @@ import { createCss } from '../src/index.js'
 
 describe('Issue #519', () => {
 	test('locally scoped token works 1 time', () => {
-		const { css, toString } = createCss({})
+		const { css, toString } = createCss({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -13,13 +13,13 @@ describe('Issue #519', () => {
 		})()
 
 		expect(toString()).toBe(
-			'.sxuuu2e{--sx--syntax:red;}' +
-			'.sxuuu2e h1{color:var(--sx--syntax);}'
+			'.fusionuuu2e{--fusion--syntax:red;}' +
+			'.fusionuuu2e h1{color:var(--fusion--syntax);}'
 		) // prettier-ignore
 	})
 
 	test('locally scoped token works 2 times', () => {
-		const { css, toString } = createCss({})
+		const { css, toString } = createCss({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -34,14 +34,14 @@ describe('Issue #519', () => {
 		})()
 
 		expect(toString()).toBe(
-			'.sxyrd68{--sx--syntax:red;}' +
-			'.sxyrd68 h1{color:var(--sx--syntax);}' +
-			'.sxyrd68 h2{color:var(--sx--syntax);}'
+			'.fusionyrd68{--fusion--syntax:red;}' +
+			'.fusionyrd68 h1{color:var(--fusion--syntax);}' +
+			'.fusionyrd68 h2{color:var(--fusion--syntax);}'
 		) // prettier-ignore
 	})
 
 	test('locally scoped token works 3 times', () => {
-		const { css, toString } = createCss({})
+		const { css, toString } = createCss({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -60,10 +60,10 @@ describe('Issue #519', () => {
 		})()
 
 		expect(toString()).toBe(
-			'.sx4gdx9{--sx--syntax:red;}' +
-			'.sx4gdx9 h1{color:var(--sx--syntax);}' +
-			'.sx4gdx9 h2{color:var(--sx--syntax);}' +
-			'.sx4gdx9 h3{color:var(--sx--syntax);}'
+			'.fusion4gdx9{--fusion--syntax:red;}' +
+			'.fusion4gdx9 h1{color:var(--fusion--syntax);}' +
+			'.fusion4gdx9 h2{color:var(--fusion--syntax);}' +
+			'.fusion4gdx9 h3{color:var(--fusion--syntax);}'
 		) // prettier-ignore
 	})
 })


### PR DESCRIPTION
This PR separates "prefixing" from "token prefixing". At this time, Stitches assigns a default `prefix`, which is required to generate valid CSS classes. Authors don’t mind this, but they do mind once the default `prefix` gets assigned to tokens. We are solving this another way — the right way — but as a _patch_ this code creates a **forked prefix just for tokens**, ignoring the default `"sx"` prefix.

This **does not** remove the ability to assign custom prefixes to tokens. The change is limited to the default `"sx"` prefix, and it is only a small, temporary patch.