### PR TITLE
Fix: React.memo and key="undefined"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ scope and avoid unrelated commits.
    cd stitches
 
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream git@github.com:modulez/stitches.git
+   git remote add upstream git@github.com:modulz/stitches.git
 
    # Install the tools necessary for testing
    yarn # or npm install
@@ -53,7 +53,7 @@ scope and avoid unrelated commits.
    # Build current code
    yarn build # or npm run build
    ```
-   
+
    > Note: ensure your version of Node is 14 or higher to run scripts
 
    ```bash

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -33,7 +33,7 @@ const createCss = (init) => {
 					} = composition(initProps)
 
 					/** React element. */
-					return { constructor: undefined, $$typeof: $$typeofElement, props, ref, type, __v: 0 }
+					return { $$typeof: $$typeofElement, key: null, props, ref, type }
 				},
 				$$typeof: $$typeofForward,
 				displayName: 'Stitches',

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -18,7 +18,7 @@ const createCss = (init) => {
 			const defaultType = inits.map((init) => (Object(init).stitchesType ? init.stitchesType : init)).find((init) => init) || 'span'
 			const composition = sheet.css(...inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof)))
 
-			/** This is a React component in the form of a forwarded ref object, with a few extra Stitches properties */
+			/** This is a React component in the form of a forwarded ref object, with a few extra Stitches properties. */
 			return {
 				/** The render function on the forwarded ref object returns a React element. */
 				render(
@@ -26,10 +26,9 @@ const createCss = (init) => {
 					initProps,
 					ref,
 				) {
-					// express the component, extracting `props`, `as` & `ref`
+					/** Express the component, extracting `props` & `as`. */
 					const {
 						props: { as: type = defaultType, ...props },
-						...expressedProps // eslint-disable-line no-unused-vars
 					} = composition(initProps)
 
 					/** React element. */
@@ -38,7 +37,7 @@ const createCss = (init) => {
 				$$typeof: $$typeofForward,
 				displayName: 'Stitches',
 
-				/** Below are all Stitches properties */
+				/** Below are all Stitches properties. */
 				[$$composers]: composition[$$composers],
 				[Symbol.toPrimitive]() {
 					return composition.selector

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -10,7 +10,7 @@ const createCss = (init) => {
 	const sheet = createCoreCss(init)
 
 	return assign(sheet, {
-		/** Returns a React forwarded ref object. */
+		/** Returns a React component in the form of a forwarded ref object. */
 		styled: (
 			/** Type of component. */
 			...inits
@@ -18,9 +18,9 @@ const createCss = (init) => {
 			const defaultType = inits.map((init) => (Object(init).stitchesType ? init.stitchesType : init)).find((init) => init) || 'span'
 			const composition = sheet.css(...inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof)))
 
-			/** This is a React forwarded ref object, with a few extra Stitches properties */
+			/** This is a React component in the form of a forwarded ref object, with a few extra Stitches properties */
 			return {
-				/** The render function is the React component on the forwarded ref object, it returns a React element. */
+				/** The render function on the forwarded ref object returns a React element. */
 				render(
 					/** Props used to determine the expression of the current component. */
 					initProps,

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -10,49 +10,50 @@ const createCss = (init) => {
 	const sheet = createCoreCss(init)
 
 	return assign(sheet, {
-		/** Returns a React component. */
+		/** Returns a React forwarded ref object. */
 		styled: (
 			/** Type of component. */
 			...inits
 		) => {
-			const defaultType = inits.map((init) => (Object(init).type ? init.type : init)).find((init) => init) || 'span'
+			const defaultType = inits.map((init) => (Object(init).stitchesType ? init.stitchesType : init)).find((init) => init) || 'span'
 			const composition = sheet.css(...inits.filter((init) => $$composers in Object(init) || (init && typeof init === 'object' && !init.$$typeof)))
 
-			/** Returns a React element. */
-			return Object.setPrototypeOf(
-				{
-					render(
-						/** Props used to determine the expression of the current component. */
-						initProps,
-						ref,
-					) {
-						// express the component, extracting `props`, `as` & `ref`
-						const {
-							props: { as: type = defaultType, ...props },
-							...expressedProps // eslint-disable-line no-unused-vars
-						} = composition(initProps)
+			/** This is a React forwarded ref object, with a few extra Stitches properties */
+			return {
+				/** The render function is the React component on the forwarded ref object, it returns a React element. */
+				render(
+					/** Props used to determine the expression of the current component. */
+					initProps,
+					ref,
+				) {
+					// express the component, extracting `props`, `as` & `ref`
+					const {
+						props: { as: type = defaultType, ...props },
+						...expressedProps // eslint-disable-line no-unused-vars
+					} = composition(initProps)
 
-						/** React element. */
-						return { constructor: undefined, $$typeof: $$typeofElement, props, ref, type, __v: 0 }
-					},
-					$$typeof: $$typeofForward,
-					[$$composers]: composition[$$composers],
-					[Symbol.toPrimitive]() {
-						return composition.selector
-					},
-					toString() {
-						return composition.selector
-					},
-					get className() {
-						return composition.className
-					},
-					get selector() {
-						return composition.selector
-					},
-					type: defaultType,
+					/** React element. */
+					return { constructor: undefined, $$typeof: $$typeofElement, props, ref, type, __v: 0 }
 				},
-				Object(defaultType),
-			)
+				$$typeof: $$typeofForward,
+				displayName: 'Stitches',
+
+				/** Below are all Stitches properties */
+				[$$composers]: composition[$$composers],
+				[Symbol.toPrimitive]() {
+					return composition.selector
+				},
+				toString() {
+					return composition.selector
+				},
+				get className() {
+					return composition.className
+				},
+				get selector() {
+					return composition.selector
+				},
+				stitchesType: defaultType,
+			}
 		},
 	})
 }

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -26,7 +26,7 @@ const createCss = (init) => {
 					initProps,
 					ref,
 				) {
-					/** Express the component, extracting `props` & `as`. */
+					/** Express the composition, extracting `props` & `as`. */
 					const {
 						props: { as: type = defaultType, ...props },
 					} = composition(initProps)

--- a/packages/react/tests/component.js
+++ b/packages/react/tests/component.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import createCss from '../src/index.js'
 
 describe('Components', () => {
-	test('The `styled` function returns a React forwarded ref object', () => {
+	test('The `styled` function returns a React component in the form of a forwarded ref object', () => {
 		const { styled } = createCss()
 		const component = styled()
 		const expression = component.render()
@@ -12,7 +12,7 @@ describe('Components', () => {
 		expect(React.isValidElement(expression)).toBe(true)
 	})
 
-	test('The `styled` function creates an implicit span component', () => {
+	test('The `styled` function creates an implicit span element', () => {
 		const { styled } = createCss()
 		const component = styled()
 		const expression = component.render()
@@ -22,7 +22,7 @@ describe('Components', () => {
 		expect(expression.type).toBe('span')
 	})
 
-	test('The `styled` function can create an explicit div component', () => {
+	test('The `styled` function can create an explicit div element', () => {
 		const { styled } = createCss()
 		const component = styled('div')
 		const expression = component.render()
@@ -32,7 +32,7 @@ describe('Components', () => {
 		expect(expression.type).toBe('div')
 	})
 
-	test('The `styled` function can create an explicit React component', () => {
+	test('The `styled` function can create an element from an explicit React component', () => {
 		function TextComponent() {
 			return 'text'
 		}
@@ -46,11 +46,8 @@ describe('Components', () => {
 		expect(expression.type).toBe(TextComponent)
 	})
 
-	test('The `styled` function can create an explicit forwarded ref React component', () => {
-		const ForwardedComponent = {
-			$$typeof: Symbol.for('react.forward_ref'),
-			render: () => 'text',
-		}
+	test('The `styled` function can create an element from an explicit forwarded ref React component', () => {
+		const ForwardedComponent = React.forwardRef(() => 'text')
 
 		const { styled } = createCss()
 		const component = styled(ForwardedComponent)
@@ -61,8 +58,8 @@ describe('Components', () => {
 		expect(expression.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
 	})
 
-	test('The `styled` function can create an explicit React memo component', () => {
-		const MyComp = () => null
+	test('The `styled` function can create an element from an explicit React memo component', () => {
+		const MyComp = () => 'text'
 		const MyCompMemo = React.memo(MyComp)
 
 		const { styled } = createCss()
@@ -74,7 +71,7 @@ describe('Components', () => {
 		expect(expression.type.$$typeof).toBe(Symbol.for('react.memo'))
 	})
 
-	test('The `styled` function creates a React element with key: null', () => {
+	test('The `styled` function creates an element with key: null', () => {
 		const { styled } = createCss()
 		const component = styled()
 		const expression = component.render()

--- a/packages/react/tests/component.js
+++ b/packages/react/tests/component.js
@@ -2,35 +2,51 @@ import * as React from 'react'
 import createCss from '../src/index.js'
 
 describe('Components', () => {
-	test('The `styled` function returns an implicit span component', () => {
+	test('The `styled` function returns a React forwarded ref object', () => {
 		const { styled } = createCss()
 		const component = styled()
+		const expression = component.render()
 
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
-		expect(component.stitchesType).toBe('span')
+		expect(component.render).toBeInstanceOf(Function)
+		expect(React.isValidElement(expression)).toBe(true)
 	})
 
-	test('The `styled` function can return an explicit div component', () => {
+	test('The `styled` function creates an implicit span component', () => {
+		const { styled } = createCss()
+		const component = styled()
+		const expression = component.render()
+
+		expect(component.stitchesType).toBe('span')
+		expect(React.isValidElement(expression)).toBe(true)
+		expect(expression.type).toBe('span')
+	})
+
+	test('The `styled` function can create an explicit div component', () => {
 		const { styled } = createCss()
 		const component = styled('div')
+		const expression = component.render()
 
-		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
 		expect(component.stitchesType).toBe('div')
+		expect(React.isValidElement(expression)).toBe(true)
+		expect(expression.type).toBe('div')
 	})
 
-	test('The `styled` function can return an explicit React component', () => {
+	test('The `styled` function can create an explicit React component', () => {
 		function TextComponent() {
 			return 'text'
 		}
 
 		const { styled } = createCss()
 		const component = styled(TextComponent)
+		const expression = component.render()
 
-		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
 		expect(component.stitchesType).toBe(TextComponent)
+		expect(React.isValidElement(expression)).toBe(true)
+		expect(expression.type).toBe(TextComponent)
 	})
 
-	test('The `styled` function can return an explicit forwarded ref React component', () => {
+	test('The `styled` function can create an explicit forwarded ref React component', () => {
 		const ForwardedComponent = {
 			$$typeof: Symbol.for('react.forward_ref'),
 			render: () => 'text',
@@ -40,13 +56,12 @@ describe('Components', () => {
 		const component = styled(ForwardedComponent)
 		const expression = component.render()
 
-		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
 		expect(component.stitchesType).toBe(ForwardedComponent)
-		expect(expression.$$typeof).toBe(Symbol.for('react.element'))
+		expect(React.isValidElement(expression)).toBe(true)
 		expect(expression.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
 	})
 
-	test('The `styled` function can return an explicit React memo component', () => {
+	test('The `styled` function can create an explicit React memo component', () => {
 		const MyComp = () => null
 		const MyCompMemo = React.memo(MyComp)
 
@@ -54,9 +69,17 @@ describe('Components', () => {
 		const component = styled(MyCompMemo)
 		const expression = component.render()
 
-		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
 		expect(component.stitchesType).toBe(MyCompMemo)
-		expect(expression.$$typeof).toBe(Symbol.for('react.element'))
+		expect(React.isValidElement(expression)).toBe(true)
 		expect(expression.type.$$typeof).toBe(Symbol.for('react.memo'))
+	})
+
+	test('The `styled` function creates a React element with key: null', () => {
+		const { styled } = createCss()
+		const component = styled()
+		const expression = component.render()
+
+		expect(React.isValidElement(expression)).toBe(true)
+		expect(expression.key).toBe(null)
 	})
 })

--- a/packages/react/tests/component.js
+++ b/packages/react/tests/component.js
@@ -47,13 +47,13 @@ describe('Components', () => {
 	})
 
 	test('The `styled` function can create an element from an explicit forwarded ref React component', () => {
-		const ForwardedComponent = React.forwardRef(() => 'text')
+		const ForwardedRefComponent = React.forwardRef((_, ref) => React.createElement('div', { ref }))
 
 		const { styled } = createCss()
-		const component = styled(ForwardedComponent)
+		const component = styled(ForwardedRefComponent)
 		const expression = component.render()
 
-		expect(component.stitchesType).toBe(ForwardedComponent)
+		expect(component.stitchesType).toBe(ForwardedRefComponent)
 		expect(React.isValidElement(expression)).toBe(true)
 		expect(expression.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
 	})

--- a/packages/react/tests/component.js
+++ b/packages/react/tests/component.js
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import createCss from '../src/index.js'
 
 describe('Components', () => {
@@ -6,7 +7,7 @@ describe('Components', () => {
 		const component = styled()
 
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
-		expect(component.type).toBe('span')
+		expect(component.stitchesType).toBe('span')
 	})
 
 	test('The `styled` function can return an explicit div component', () => {
@@ -14,7 +15,7 @@ describe('Components', () => {
 		const component = styled('div')
 
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
-		expect(component.type).toBe('div')
+		expect(component.stitchesType).toBe('div')
 	})
 
 	test('The `styled` function can return an explicit React component', () => {
@@ -26,10 +27,10 @@ describe('Components', () => {
 		const component = styled(TextComponent)
 
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
-		expect(component.type).toBe(TextComponent)
+		expect(component.stitchesType).toBe(TextComponent)
 	})
 
-	test('The `styled` function can return an explicit forwarded React component', () => {
+	test('The `styled` function can return an explicit forwarded ref React component', () => {
 		const ForwardedComponent = {
 			$$typeof: Symbol.for('react.forward_ref'),
 			render: () => 'text',
@@ -37,8 +38,25 @@ describe('Components', () => {
 
 		const { styled } = createCss()
 		const component = styled(ForwardedComponent)
+		const expression = component.render()
 
 		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
-		expect(component.type).toBe(ForwardedComponent)
+		expect(component.stitchesType).toBe(ForwardedComponent)
+		expect(expression.$$typeof).toBe(Symbol.for('react.element'))
+		expect(expression.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
+	})
+
+	test('The `styled` function can return an explicit React memo component', () => {
+		const MyComp = () => null
+		const MyCompMemo = React.memo(MyComp)
+
+		const { styled } = createCss()
+		const component = styled(MyCompMemo)
+		const expression = component.render()
+
+		expect(component.$$typeof).toBe(Symbol.for('react.forward_ref'))
+		expect(component.stitchesType).toBe(MyCompMemo)
+		expect(expression.$$typeof).toBe(Symbol.for('react.element'))
+		expect(expression.type.$$typeof).toBe(Symbol.for('react.memo'))
 	})
 })


### PR DESCRIPTION
Hi, this is a PR for #568 and #579.

Fixes #568 - Stitches removes the memoization from components wrapped in `React.memo`, e.g. `styled(React.memo(MyComp))`.

Partially fixes #579 - Stitches creates elements with `key="undefined"` (fixed), and "rendered by" component stack missing in React dev tools (requires change to using `React.createElement(...)`, not included in this PR).

---

### Fix for #568 `styled(React.memo(Component))`

Essentially the issue is that the `styled` function is returning a React component in the form of a forwarded ref object with some extra Stitches properties. One of those extra properties is `type` which is set to the value of the element/component passed into `styled`.

The `type` property on a forwarded ref object is not used by React (it's ignored), but Stitches uses it when composing multiple calls to `styled`, e.g. `const Div = styled('div'); const GreenDiv = styled(Div, { color: 'green' });`, so there's only one forwarded ref object returned no matter how many times `styled` is composed (instead of returning multiple nested forwarded ref objects).

However, the React memo object (returned from `React.memo(Comp)`) does have a `type` property set the value of the component that it's memoizing. When a React memo object was passed into `styled` like `styled(React.memo(Comp))`, Stitches discarded the React memo object thinking the `type` property was added from a previous call to `styled`, when really the React memo object needs to be used as the `type` for the React element returned from the forwarded ref object's `render` function.

I think it's best to leave the `type` property to React and only use it when it's meant to be consumed by React, so I renamed the one on the forwarded ref object to `stitchesType`. This fixes the issue.

---

These forwarded ref object and memo object examples may be helpful as a reference when reviewing this PR.
React source code: [ReactForwardRef.js](https://github.com/facebook/react/blob/master/packages/react/src/ReactForwardRef.js) and [ReactMemo.js](https://github.com/facebook/react/blob/master/packages/react/src/ReactMemo.js).

```js
// React forwarded ref object, returned from React.forwardRef((props, ref) => {...})
const forwardedRefObject = {
  $$typeof: Symbol.for('react.forward_ref'),
  render: (props, ref) => {
    // the render function needs to return something that react can render
    // for example a react element object, like:
    return <div>hello</div>;
    // OR
    return React.createElement('div', { children: 'hello' });
  },
};
```

```js
// React memo object, returned from React.memo(MyComponent, compare)
const memoObject = {
  $$typeof: Symbol.for('react.memo'),
  type: MyComponent,
  compare: null, // null means react does a standard shallow comparison
  // OR use a custom areEqual function
  // note that React.memo sets compare to null on the object
  // if a value is not passed in to React.memo
};
```

---

### Fix for #579 `key="undefined"`

The `key="undefined"` issue is because `React.createElement(...)` explicitly sets `key: null` on the element object it returns if a key prop is not passed to the React component. This is why when Stitches left key undefined on the element object React interpreted it as a literal key value (only `null` means no key), so `key="undefined"` showed up on the element created by Stitches. I added `key: null` to the React element object which fixes this issue.

It's usually recommended to generate a React element object by calling `React.createElement(...)` instead of manually creating it, as that avoids these pitfalls. Also, with using `React.createElement(...)` it adds the `_owner` property (see below), and other dev only properties for a better dev experience.

I think it would be a good idea to switch to using `React.createElement(...)` to create the element object, but I did not make that change in this PR. I don't think avoiding the `React.createElement` function call is providing a performance benefit (the function call is very inexpensive, especially in production), and AFAICT there aren't any other benefits to Stitches from creating the object manually.

React source code for `createElement`: [ReactElement.js](https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js)
```js
// React element object, returned from React.createElement
// and the new JSX transform
const elementObject = {
  $$typeof: Symbol.for('react.element'),

  // MyComponent, 'div', etc
  type: type,

  // React.createElement() explicitly sets `key: null`
  // if a key prop is not passed to the React component
  key: key,

  // the props that are on the element object are the props
  // passed into the component with key and ref removed
  props: propsWithOutKeyAndRef,
  ref: ref,

  // records the component responsible for creating this element
  _owner: ReactCurrentOwner.current,
  // this comes from Fiber, Stitches can't access it
  // it's used in dev tools to show the "rendered by" list
  // currently all Stitches created elements just have "react-dom"
  // in the dev tools "rendered by" list b/c _owner is missing

  // additional dev only properties, see React source code for more info
  _store,
  _self,
  _source,
};
```