### PR TITLE
0.2.x — cleanup: organize and reduce `css` code

### DIFF
--- a/packages/core/src/convert/toHash.js
+++ b/packages/core/src/convert/toHash.js
@@ -15,7 +15,7 @@ const toPhash = (/** @type {number} */ h, /** @type {string} */ x) => {
 	return h
 }
 
-export const toHash = (/** @type {string} */ value) => toAlphabeticName(
+export const toHash = (/** @type {object} */ value) => toAlphabeticName(
 	toPhash(
 		5381,
 		JSON.stringify(value)

--- a/packages/core/src/features/css.d.ts
+++ b/packages/core/src/features/css.d.ts
@@ -1,0 +1,94 @@
+/** CSS styles. */
+export type Styling = {
+	[prelude: string]: number | string | Styling
+}
+
+/* ========================================================================== */
+
+/** Composer as it has been authored. */
+export type InitComposer = {
+	variants?: {
+		[name: string]: {
+			[value: string]: Styling
+		}
+	}
+
+	compoundVariants?: {
+		css: Styling
+	} & {
+		[name: string]: boolean | number | string | undefined
+	}
+
+	defaultVariants?: {
+		[name: string]: string
+	}
+} & Styling
+
+/** Composer as it has been processed. */
+export type Composer = [
+	/** Composer base class name. */
+	string,
+
+	/** Composer base styles. */
+	Styling,
+
+	/** Composer variants. */
+	VariantTuple[],
+
+	/** Composer compound variants. */
+	VariantTuple[],
+
+	/** Composer variants pairings with any default variants applied. */
+	PrefilledVariants,
+
+	/** Composer undefined variants. */
+	UndefinedVariants,
+]
+
+/* ========================================================================== */
+
+/** Variant key/pair values that must match for the variant to be applied. */
+export type VariantMatcher = {
+	[name: string]: string
+}
+
+export type VariantTuple = [
+	VariantMatcher,
+	Styling,
+	/** Whether the variant styles are empty. */
+	boolean,
+]
+
+export type VariantProps = {
+	[name: string]: string | { [breakpoint: string]: string }
+}
+
+/* ========================================================================== */
+
+export type PrefilledVariants = {
+	[name: string]: string
+}
+
+export type UndefinedVariants = string[]
+
+/* ========================================================================== */
+
+export type Render = (
+	props: {
+		children: {}[]
+		css: Styling
+	} & {
+		[name: string]: any
+	},
+) => unknown
+
+/* ========================================================================== */
+
+export type Config = {
+	prefix: string
+	media: {
+		[name: string]: string
+	}
+}
+
+/* ========================================================================== */

--- a/packages/core/src/features/css.js
+++ b/packages/core/src/features/css.js
@@ -8,20 +8,16 @@ import { toCssRules } from '../convert/toCssRules.js'
 import { toHash } from '../convert/toHash.js'
 import { toTailDashed } from '../convert/toTailDashed.js'
 
-/** @typedef {import('.').Config} Config */
-/** @typedef {import('.').Style} Style */
-/** @typedef {import('.').Group} Group */
-/** @typedef {import('.').GroupRules} GroupRules */
-/** @typedef {import('.').GroupSheet} GroupSheet */
-
-/** @typedef {[string, {}, Variant[], { [name: string]: any }], Variant[], Variant[]} Composer */
-/** @typedef {{ [name: string]: string }} VariantMatches */
-/** @typedef {[VariantMatches, {}]} Variant */
-
-/** @typedef {{ css: Style } & VariantMatches} CompoundVariantsInit */
-/** @typedef {{ [name: string]: any }} DefaultVariants */
-/** @typedef {{ [name: string]: { [value: string]: Style } }} SingularVariantsInit */
-/** @typedef {{ variants: SingularVariantsInit, compoundVariants: CompoundVariantsInit, defaultVariants: DefaultVariants } & Style} ComposerInit */
+/** @typedef {import('./css').Composer} Composer */
+/** @typedef {import('./css').Config} Config */
+/** @typedef {import('./css').InitComposer} InitComposer */
+/** @typedef {import('./css').PrefilledVariants} PrefilledVariants */
+/** @typedef {import('./css').Render} Render */
+/** @typedef {import('./css').Styling} Styling */
+/** @typedef {import('./css').UndefinedVariants} UndefinedVariants */
+/** @typedef {import('./css').VariantMatcher} VariantMatcher */
+/** @typedef {import('./css').VariantProps} VariantProps */
+/** @typedef {import('./css').VariantTuple} VariantTuple */
 
 const createComponentFunctionMap = createMemo()
 
@@ -72,243 +68,157 @@ export const createComponentFunction = (/** @type {Config} */ config, /** @type 
 
 		// set the component type if none was set
 		if (componentType == null) componentType = 'span'
-		if (!composers.size) composers.add(['PJLV', {}, [], Object.create(null), [], [], []])
+		if (!composers.size) composers.add(['PJLV', {}, [], [], {}, []])
 
 		return createRenderer(config, componentType, composers, sheet)
 	})
 
 /** Creates a composer from a configuration object. */
-const createComposer = (/** @type {ComposerInit} */ { variants: singularVariants, compoundVariants, defaultVariants, ...style }, /** @type {Config} */ config) => {
+const createComposer = (/** @type {InitComposer} */ { variants: initSingularVariants, compoundVariants: initCompoundVariants, defaultVariants: initDefaultVariants, ...style }, /** @type {Config} */ config) => {
 	/** @type {string} Composer Unique Identifier. @see `{CONFIG_PREFIX}-?c-{STYLE_HASH}` */
 	const className = `${toTailDashed(config.prefix)}c-${toHash(style)}`
 
-	/** @type {Variant[]} */
-	const variants = []
+	/** @type {VariantTuple[]} */
+	const singularVariants = []
 
-	const composerSingularVariants = []
-	const composerCompoundVariants = []
-	const processedDefaultVariants = Object.create(null)
-	const canHaveUndefinedVariants = []
+	/** @type {VariantTuple[]} */
+	const compoundVariants = []
 
-	for (const variantName in defaultVariants) {
-		processedDefaultVariants[variantName] = String(defaultVariants[variantName])
+	/** @type {PrefilledVariants} */
+	const prefilledVariants = Object.create(null)
+
+	/** @type {UndefinedVariants} */
+	const undefinedVariants = []
+
+	for (const variantName in initDefaultVariants) {
+		prefilledVariants[variantName] = String(initDefaultVariants[variantName])
 	}
 
 	// add singular variants
-	if (typeof singularVariants === 'object' && singularVariants) {
-		for (const name in singularVariants) {
-			if (!hasOwn(processedDefaultVariants, name)) processedDefaultVariants[name] = 'undefined'
+	if (typeof initSingularVariants === 'object' && initSingularVariants) {
+		for (const name in initSingularVariants) {
+			if (!hasOwn(prefilledVariants, name)) prefilledVariants[name] = 'undefined'
 
-			const variantPairs = singularVariants[name]
+			const variantPairs = initSingularVariants[name]
 
 			for (const pair in variantPairs) {
-				/** @type {VariantMatches} */
+				/** @type {VariantMatcher} */
 				const vMatch = { [name]: String(pair) }
 
-				if (String(pair) === 'undefined') canHaveUndefinedVariants.push(name)
+				if (String(pair) === 'undefined') undefinedVariants.push(name)
 
-				/** @type {Style} */
 				const vStyle = variantPairs[pair]
 
-				/** @type {Variant} */
-				const variant = [vMatch, vStyle]
+				/** @type {VariantTuple} */
+				const variant = [vMatch, vStyle, !hasNames(vStyle)]
 
-				variants.push(variant)
-
-				composerSingularVariants.push([
-					vMatch,
-					vStyle,
-				])
+				singularVariants.push(variant)
 			}
 		}
 	}
 
 	// add compound variants
-	if (typeof compoundVariants === 'object' && compoundVariants) {
-		for (const compoundVariant of compoundVariants) {
+	if (typeof initCompoundVariants === 'object' && initCompoundVariants) {
+		for (const compoundVariant of initCompoundVariants) {
+			/** @type {InitComposer['compoundVariants']} */
 			let { css: vStyle, ...vMatch } = compoundVariant
 
-			vStyle = (typeof vStyle === 'object' && vStyle) || {}
+			vStyle = typeof vStyle === 'object' && vStyle || {}
 
+			// serialize all compound variant pairs
 			for (const name in vMatch) vMatch[name] = String(vMatch[name])
 
-			/** @type {Variant} */
-			const variant = [vMatch, vStyle]
+			/** @type {VariantTuple} */
+			const variant = [vMatch, vStyle, !hasNames(vStyle)]
 
-			variants.push(variant)
-
-			composerCompoundVariants.push([
-				vMatch,
-				vStyle,
-			])
+			compoundVariants.push(variant)
 		}
 	}
 
-	return /** @type {Composer} */ ([className, style, variants, processedDefaultVariants, composerSingularVariants, composerCompoundVariants, canHaveUndefinedVariants])
+	return /** @type {Composer} */ ([className, style, singularVariants, compoundVariants, prefilledVariants, undefinedVariants])
 } // prettier-ignore
 
 const createRenderer = (
 	/** @type {Config} */ config,
 	/** @type {string | Function} */ type,
 	/** @type {Set<Composer>} */ composers,
-	/** @type {GroupSheet} */ sheet
+	/** @type {{}} */ sheet
 ) => {
-	const [className] = composers.keys().next().value
-	const selector = `.${className}`
+	const [
+		initialClassName,
+		baseClassNames,
+		prefilledVariants,
+		undefinedVariants
+	] = getPreparedDataFromComposers(composers)
 
+	const selector = `.${initialClassName}`
+
+	/** @type {Render} */
 	const render = (props) => {
-		props = (typeof props === 'object' && props) || {}
+		props = typeof props === 'object' && props || emptyProps
 
+		// 1. we cannot mutate `props`
+		// 2. we delete variant props
+		// 3. we delete `css` prop
+		// therefore: we must create a new props & css variables
 		const { css, ...forwardProps } = props
 
-		let comparablePropsLead = {}
-		let comparablePropsTail = { ...forwardProps }
+		/** @type {VariantProps} */
+		const variantProps = {}
 
-		const [defaultVariants, canHaveUndefinedVariants] = getDefaultVariantsFromComposers(composers)
+		for (const name in prefilledVariants) {
+			delete forwardProps[name]
 
-		for (const name in defaultVariants) {
-			if (name in comparablePropsTail) {
-				let propData = comparablePropsTail[name]
+			if (name in props) {
+				let data = props[name]
 
-				if (typeof propData === 'object' && propData !== null) {
-					comparablePropsTail[name] = {
-						'@initial': defaultVariants[name],
-						...propData,
+				if (typeof data === 'object' && data) {
+					variantProps[name] = {
+						'@initial': prefilledVariants[name],
+						...data,
 					}
-					continue
-				}
+				} else {
+					data = String(data)
 
-				propData = String(propData)
-
-				if (propData === 'undefined' && !canHaveUndefinedVariants.has(name)) {
-					comparablePropsTail[name] = defaultVariants[name]
+					variantProps[name] = (
+						data === 'undefined' && !undefinedVariants.has(name)
+							? prefilledVariants[name]
+						: data
+					)
 				}
 			} else {
-				comparablePropsLead[name] = defaultVariants[name]
+				variantProps[name] = prefilledVariants[name]
 			}
 		}
 
-		const { children, ...comparableProps } = { ...comparablePropsLead, ...comparablePropsTail }
+		const classSet = new Set([ ...baseClassNames ])
 
-		/** @type {string[]} */
-		const classSet = new Set
+		// 1. builds up the variants (fills in defaults, calculates @initial on responsive, etc.)
+		// 2. iterates composers
+		// 2.1. add their base class
+		// 2.2. iterate their variants, add their variant classes
+		// 2.2.1. orders regular variants before responsive variants
+		// 2.3. iterate their compound variants, add their compound variant classes
 
-		for (const [composerClassName, composerStyle, composerVariants, _, composerSingularVariants, composerCompoundVariants] of composers) {
-			classSet.add(composerClassName)
-
-			if (!sheet.rules.styled.cache.has(composerClassName)) {
-				sheet.rules.styled.cache.add(composerClassName)
+		for (const [composerBaseClass, composerBaseStyle, singularVariants, compoundVariants] of composers) {
+			if (!sheet.rules.styled.cache.has(composerBaseClass)) {
+				sheet.rules.styled.cache.add(composerBaseClass)
 
 				let index = sheet.rules.styled.group.cssRules.length
 
-				toCssRules(composerStyle, [`.${composerClassName}`], [], config, cssText => {
+				toCssRules(composerBaseStyle, [`.${composerBaseClass}`], [], config, cssText => {
 					sheet.rules.styled.group.insertRule(cssText, index++)
 				})
 			}
 
-			const singularVariantsToAdd = []
-			const compoundVariantsToAdd = []
-
-			singularVariants: for (let [vMatch, vStyle] of composerSingularVariants) {
-				// skip empty variants
-				if (!hasNames(vStyle)) continue
-
-				let variantIndex = 0
-
-				for (const name in vMatch) {
-					delete forwardProps[name]
-
-					const matchingPair = vMatch[name]
-
-					let comparablePair = comparableProps[name]
-
-					comparablePair = typeof comparablePair === 'object' && comparablePair || String(comparablePair)
-
-					// exact matches
-					if (comparablePair === matchingPair) continue
-
-					// responsive matches
-					else if (name in comparableProps && typeof comparablePair === 'object' && comparablePair !== null) {
-						let didMatch = false
-
-						for (const query in comparablePair) {
-							if (String(comparablePair[query]) === matchingPair) {
-								if (query !== '@initial') {
-									vStyle = {
-										[query in config.media ? config.media[query] : query]: vStyle
-									}
-								}
-
-								variantIndex += Object.keys(comparablePair).indexOf(query)
-
-								didMatch = true
-							}
-						}
-
-						if (!didMatch) continue singularVariants
-					}
-
-					// non-matches
-					else continue singularVariants
-				}
-
-				const vName = String(Object.keys(vMatch))
-				const vClass = `${vName}-${vMatch[vName]}`
-
-				;(singularVariantsToAdd[variantIndex] = singularVariantsToAdd[variantIndex] || []).push([vClass, vStyle])
-			}
-
-			compoundVariants: for (let [vMatch, vStyle] of composerCompoundVariants) {
-				// skip empty variants
-				if (!hasNames(vStyle)) continue
-
-				let variantIndex = 0
-
-				for (const name in vMatch) {
-					delete forwardProps[name]
-
-					const matchingPair = vMatch[name]
-
-					let comparablePair = comparableProps[name]
-
-					comparablePair = typeof comparablePair === 'object' && comparablePair || String(comparablePair)
-
-					// exact matches
-					if (comparablePair === matchingPair) continue
-
-					// responsive matches
-					else if (name in comparableProps && typeof comparablePair === 'object' && comparablePair !== null) {
-						let didMatch = false
-
-						for (const query in comparablePair) {
-							if (String(comparablePair[query]) === matchingPair) {
-								if (query !== '@initial') {
-									vStyle = {
-										[query in config.media ? config.media[query] : query]: vStyle
-									}
-								}
-
-								variantIndex += Object.keys(comparablePair).indexOf(query)
-
-								didMatch = true
-							}
-						}
-
-						if (!didMatch) continue compoundVariants
-					}
-
-					// non-matches
-					else continue compoundVariants
-				}
-
-				;(compoundVariantsToAdd[variantIndex] = compoundVariantsToAdd[variantIndex] || []).push(vStyle)
-			}
+			const singularVariantsToAdd = getTargetVariantsToAdd(singularVariants, variantProps, config.media)
+			const compoundVariantsToAdd = getTargetVariantsToAdd(compoundVariants, variantProps, config.media, true)
 
 			for (const variantToAdd of singularVariantsToAdd) {
 				if (variantToAdd === undefined) continue
 
 				for (const [vClass, vStyle] of variantToAdd) {
-					const variantClassName = `${composerClassName}-${toHash(vStyle)}-${vClass}`
+					const variantClassName = `${composerBaseClass}-${toHash(vStyle)}-${vClass}`
 
 					classSet.add(variantClassName)
 
@@ -327,8 +237,8 @@ const createRenderer = (
 			for (const variantToAdd of compoundVariantsToAdd) {
 				if (variantToAdd === undefined) continue
 
-				for (const vStyle of variantToAdd) {
-					const variantClassName = `${composerClassName}-${toHash(vStyle)}-cv`
+				for (const [vClass, vStyle] of variantToAdd) {
+					const variantClassName = `${composerBaseClass}-${toHash(vStyle)}-${vClass}`
 
 					classSet.add(variantClassName)
 
@@ -348,7 +258,7 @@ const createRenderer = (
 		// apply css property styles
 		if (typeof css === 'object' && css) {
 			/** @type {string} Inline Class Unique Identifier. @see `{COMPOSER_UUID}-i{VARIANT_UUID}-css` */
-			const iClass = `${className}-i${toHash(css)}-css`
+			const iClass = `${initialClassName}-i${toHash(css)}-css`
 
 			classSet.add(iClass)
 
@@ -381,31 +291,121 @@ const createRenderer = (
 	}
 
 	const toString = () => {
-		if (!sheet.rules.styled.cache.has(className)) render()
-		return className
+		if (!sheet.rules.styled.cache.has(initialClassName)) render()
+		return initialClassName
 	}
 
 	return define(render, {
 		type,
-		className,
+		className: initialClassName,
 		selector,
 		[$$composers]: composers,
 		toString,
 	})
 } // prettier-ignore
 
-const getDefaultVariantsFromComposers = (/** @type {Set<Composer>} */ composers) => {
-	const combinedDefaultVariants = {}
+/** Returns useful data that can be known before rendering. */
+const getPreparedDataFromComposers = (/** @type {Set<Composer>} */ composers) => {
+	/** Class name of the first composer. */
+	let initialClassName = ''
 
-	const combinedCanHaveUndefinedVariants = []
+	/** @type {string[]} Combined class names for all composers. */
+	const combinedClassNames = []
 
-	for (const [, , , defaultVariants, , , canHaveUndefinedVariants] of composers) {
-		combinedCanHaveUndefinedVariants.push(...canHaveUndefinedVariants)
+	/** @type {PrefilledVariants} Combined variant pairings for all composers. */
+	const combinedPrefilledVariants = {}
 
-		for (const name in defaultVariants) {
-			combinedDefaultVariants[name] = defaultVariants[name]
+	/** @type {UndefinedVariants} List of variant names that can have an "undefined" pairing. */
+	const combinedUndefinedVariants = []
+
+	for (const [className, , , , prefilledVariants, undefinedVariants] of composers) {
+		if (initialClassName === '') initialClassName = className
+
+		combinedClassNames.push(className)
+
+		combinedUndefinedVariants.push(...undefinedVariants)
+
+		for (const name in prefilledVariants) {
+			combinedPrefilledVariants[name] = prefilledVariants[name]
 		}
 	}
 
-	return [combinedDefaultVariants, new Set(combinedCanHaveUndefinedVariants)]
+	/** @type {[string, string[], PrefilledVariants, Set<UndefinedVariants>]} */
+	const preparedData = [
+		initialClassName,
+		combinedClassNames,
+		combinedPrefilledVariants,
+		new Set(combinedUndefinedVariants)
+	]
+
+	return preparedData
+} // prettier-ignore
+
+const getTargetVariantsToAdd = (
+	/** @type {VariantTuple[]} */
+	targetVariants,
+	/** @type {VariantProps} */
+	variantProps,
+	/** @type {Config['media']} */
+	media,
+	/** @type {boolean} */
+	isCompoundVariant,
+) => {
+	/** @type {[string, Styling][][]} */
+	const targetVariantsToAdd = []
+
+	targetVariants: for (let [vMatch, vStyle, vEmpty] of targetVariants) {
+		// skip empty variants
+		if (vEmpty) continue
+
+		/** Position the variant should be inserted into. */
+		let vOrder = 0
+
+		/** @type {string & keyof typeof vMatch} */
+		let vName
+
+		for (vName in vMatch) {
+			const vPair = vMatch[vName]
+
+			let pPair = variantProps[vName]
+
+			// exact matches
+			if (pPair === vPair) continue
+			// responsive matches
+			else if (typeof pPair === 'object' && pPair) {
+				/** @type {boolean} Whether the responsive variant is matched. */
+				let didMatch
+
+				let qOrder = 0
+
+				for (const query in pPair) {
+					if (vPair === String(pPair[query])) {
+						if (query !== '@initial') {
+							vStyle = {
+								[query in media ? media[query] : query]: vStyle,
+							}
+						}
+
+						vOrder += qOrder
+
+						didMatch = true
+					}
+
+					++qOrder
+				}
+
+				if (!didMatch) continue targetVariants
+			}
+
+			// non-matches
+			else continue targetVariants
+		}
+
+		;(targetVariantsToAdd[vOrder] = targetVariantsToAdd[vOrder] || []).push([isCompoundVariant ? `cv` : `${vName}-${vMatch[vName]}`, vStyle])
+	}
+
+	return targetVariantsToAdd
 }
+
+/** Fallback props object used when no props are passed. */
+const emptyProps = {}

--- a/packages/core/tests/issue-450.js
+++ b/packages/core/tests/issue-450.js
@@ -204,7 +204,7 @@ describe('Issue #450', () => {
 		test('Render component2()', () => {
 			const { component2, getCssString } = getFreshComponents()
 			const render = component2()
-			expect(render.className).toBe(`c-jyxqjt c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv c-dkRcuu`)
+			expect(render.className).toBe(`c-jyxqjt c-dkRcuu c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv`)
 			expect(getCssString()).toBe(
 				`--stitches{--:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +
@@ -223,7 +223,7 @@ describe('Issue #450', () => {
 		test('Render component2({ appearance: "secondary", color: "lightBlue" })', () => {
 			const { component2, getCssString } = getFreshComponents()
 			const render = component2({ appearance: 'secondary', color: 'lightBlue' })
-			expect(render.className).toBe(`c-jyxqjt c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv c-dkRcuu`)
+			expect(render.className).toBe(`c-jyxqjt c-dkRcuu c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv`)
 			expect(getCssString()).toBe(
 				`--stitches{--:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +

--- a/packages/react/tests/issue-450.js
+++ b/packages/react/tests/issue-450.js
@@ -141,7 +141,7 @@ describe('Issue #450', () => {
 		expect(
 			RenderOf(RoundedTile).props.className
 		).toBe(
-			`${tileComponentClass} ${variantAppearanceSecondaryClass} ${variantLightBlueClass} ${variantCompoundClass} ${roundedTileComponentClass}`
+			`${tileComponentClass} ${roundedTileComponentClass} ${variantAppearanceSecondaryClass} ${variantLightBlueClass} ${variantCompoundClass}`
 		)
 
 		// Restyled compound variants (compound is activated explicitly by props)
@@ -150,7 +150,7 @@ describe('Issue #450', () => {
 		expect(
 			RenderOf(RoundedTile, { appearance: 'secondary', color: 'lightBlue' }).props.className
 		).toBe(
-			`${tileComponentClass} ${variantAppearanceSecondaryClass} ${variantLightBlueClass} ${variantCompoundClass} ${roundedTileComponentClass}`
+			`${tileComponentClass} ${roundedTileComponentClass} ${variantAppearanceSecondaryClass} ${variantLightBlueClass} ${variantCompoundClass}`
 		)
 	})
 }) // prettier-ignore


### PR DESCRIPTION
This PR organizes 0.2.x code for the `css` function (and therefore the `styled` function as well). The hope is that the tidier code also means _faster_ code.