### PR TITLE
0.2.x — safely wrap css inserts

### DIFF
--- a/packages/core/src/createCss.js
+++ b/packages/core/src/createCss.js
@@ -57,7 +57,6 @@ export const createCss = (/** @type {Partial<Config>} */ config) => {
 			prefix,
 			getCssString: sheet.toString,
 			toString: sheet.toString,
-			[Symbol.toPrimitive]: sheet.toString,
 		}
 
 		const defaultTheme = returnValue.theme(theme)

--- a/packages/core/src/createSheet.d.ts
+++ b/packages/core/src/createSheet.d.ts
@@ -1,0 +1,24 @@
+export type SheetGroup = {
+	sheet: CSSStyleSheet
+	rules: {
+		themed: RuleGroup
+		global: RuleGroup
+		styled: RuleGroup
+		onevar: RuleGroup
+		allvar: RuleGroup
+		inline: RuleGroup
+	}
+
+	reset(): void
+	toString(): string
+}
+
+export type RuleGroup = {
+	index: number
+	group: CSSGroupingRule
+	cache: Set<string>
+
+	apply(cssText: string): void
+}
+
+export type RuleGroupNames = ['themed', 'global', 'styled', 'onevar', 'allvar', 'inline']

--- a/packages/core/src/createSheet.js
+++ b/packages/core/src/createSheet.js
@@ -1,13 +1,12 @@
-/** @typedef {import('.').GroupSheet} GroupSheet */
-/** @typedef {import('.').GroupRules} GroupRules */
-/** @typedef {import('.').GroupName} GroupName */
-/** @typedef {import('.').Group} Group */
+/** @typedef {import('./createSheet').RuleGroup} RuleGroup */
+/** @typedef {import('./createSheet').RuleGroupNames} RuleGroupNames */
+/** @typedef {import('./createSheet').SheetGroup} SheetGroup */
 
-/** @type {GroupName[]} */
+/** @type {RuleGroupNames} */
 const names = ['themed', 'global', 'styled', 'onevar', 'allvar', 'inline']
 
 export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
-	/** @type {GroupSheet} Object hosting the hydrated stylesheet. */
+	/** @type {SheetGroup} Object hosting the hydrated stylesheet. */
 	let groupSheet
 
 	const reset = () => {
@@ -137,6 +136,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([5]),
 			}
 		}
+		addApplyToGroup(rules.inline)
 
 		// conditionally generate the allvar group
 		if (!rules.allvar) {
@@ -150,6 +150,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([4]),
 			}
 		}
+		addApplyToGroup(rules.allvar)
 
 		// conditionally generate the onevar group
 		if (!rules.onevar) {
@@ -163,6 +164,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([3]),
 			}
 		}
+		addApplyToGroup(rules.onevar)
 
 		// conditionally generate the styled group
 		if (!rules.styled) {
@@ -176,6 +178,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([2]),
 			}
 		}
+		addApplyToGroup(rules.styled)
 
 		// conditionally generate the global group
 		if (!rules.global) {
@@ -189,6 +192,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([1]),
 			}
 		}
+		addApplyToGroup(rules.global)
 
 		// conditionally generate the themed group
 		if (!rules.themed) {
@@ -202,9 +206,26 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				cache: new Set([0]),
 			}
 		}
+		addApplyToGroup(rules.themed)
 	}
 
 	reset()
 
 	return groupSheet
+}
+
+const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
+	const groupingRule = group.group
+
+	let index = 0
+
+	group.apply = (cssText) => {
+		try {
+			groupingRule.insertRule(cssText, index)
+
+			++index
+		} catch (error) {
+			console.warn(error.message)
+		}
+	}
 }

--- a/packages/core/src/features/css.js
+++ b/packages/core/src/features/css.js
@@ -19,10 +19,12 @@ import { toTailDashed } from '../convert/toTailDashed.js'
 /** @typedef {import('./css').VariantProps} VariantProps */
 /** @typedef {import('./css').VariantTuple} VariantTuple */
 
+/** @typedef {import('../createSheet').SheetGroup} SheetGroup */
+
 const createComponentFunctionMap = createMemo()
 
 /** Returns a function that applies component styles. */
-export const createComponentFunction = (/** @type {Config} */ config, /** @type {GroupSheet} */ sheet) =>
+export const createComponentFunction = (/** @type {Config} */ config, /** @type {SheetGroup} */ sheet) =>
 	createComponentFunctionMap(config, () => (...args) => {
 		/** @type {string | Function} Component type, which may be a function or a string. */
 		let componentType = null
@@ -142,7 +144,7 @@ const createRenderer = (
 	/** @type {Config} */ config,
 	/** @type {string | Function} */ type,
 	/** @type {Set<Composer>} */ composers,
-	/** @type {{}} */ sheet
+	/** @type {import('../createSheet').SheetGroup} */ sheet
 ) => {
 	const [
 		initialClassName,
@@ -204,10 +206,8 @@ const createRenderer = (
 			if (!sheet.rules.styled.cache.has(composerBaseClass)) {
 				sheet.rules.styled.cache.add(composerBaseClass)
 
-				let index = sheet.rules.styled.group.cssRules.length
-
 				toCssRules(composerBaseStyle, [`.${composerBaseClass}`], [], config, cssText => {
-					sheet.rules.styled.group.insertRule(cssText, index++)
+					sheet.rules.styled.apply(cssText)
 				})
 			}
 
@@ -225,10 +225,8 @@ const createRenderer = (
 					if (!sheet.rules.onevar.cache.has(variantClassName)) {
 						sheet.rules.onevar.cache.add(variantClassName)
 
-						let index = sheet.rules.onevar.group.cssRules.length
-
 						toCssRules(vStyle, [`.${variantClassName}`], [], config, cssText => {
-							sheet.rules.onevar.group.insertRule(cssText, index++)
+							sheet.rules.onevar.apply(cssText)
 						})
 					}
 				}
@@ -245,10 +243,8 @@ const createRenderer = (
 					if (!sheet.rules.allvar.cache.has(variantClassName)) {
 						sheet.rules.allvar.cache.add(variantClassName)
 
-						let index = sheet.rules.allvar.group.cssRules.length
-
 						toCssRules(vStyle, [`.${variantClassName}`], [], config, cssText => {
-							sheet.rules.allvar.group.insertRule(cssText, index++)
+							sheet.rules.allvar.apply(cssText)
 						})
 					}
 				}
@@ -265,10 +261,8 @@ const createRenderer = (
 			if (!sheet.rules.inline.cache.has(iClass)) {
 				sheet.rules.inline.cache.add(iClass)
 
-				let index = sheet.rules.inline.group.cssRules.length
-
 				toCssRules(css, [`.${iClass}`], [], config, cssText => {
-					sheet.rules.inline.group.insertRule(cssText, index++)
+					sheet.rules.inline.apply(cssText)
 				})
 			}
 		}

--- a/packages/core/src/features/global.d.ts
+++ b/packages/core/src/features/global.d.ts
@@ -1,0 +1,15 @@
+/** CSS styles. */
+export type Styling = {
+	[prelude: string]: number | string | Styling
+}
+
+/* ========================================================================== */
+
+export type Config = {
+	prefix: string
+	media: {
+		[name: string]: string
+	}
+}
+
+/* ========================================================================== */

--- a/packages/core/src/features/global.js
+++ b/packages/core/src/features/global.js
@@ -4,15 +4,16 @@ import { define } from '../utility/define.js'
 import { toCssRules } from '../convert/toCssRules.js'
 import { toHash } from '../convert/toHash.js'
 
-/** @typedef {import('.').Config} Config */
-/** @typedef {import('.').Style} Style */
-/** @typedef {import('.').GroupSheet} GroupSheet */
+/** @typedef {import('./global').Config} Config */
+/** @typedef {import('./global').Styling} Styling */
+
+/** @typedef {import('../createSheet').SheetGroup} SheetGroup */
 
 const createGlobalFunctionMap = createMemo()
 
 /** Returns a function that applies global styles. */
-export const createGlobalFunction = (/** @type {Config} */ config, /** @type {GroupSheet} */ sheet) =>
-	createGlobalFunctionMap(config, () => (/** @type {Style} */ style) => {
+export const createGlobalFunction = (/** @type {Config} */ config, /** @type {SheetGroup} */ sheet) =>
+	createGlobalFunctionMap(config, () => (/** @type {Styling} */ style) => {
 		style = (typeof style === 'object' && style) || {}
 
 		const uuid = toHash(style)
@@ -35,10 +36,8 @@ export const createGlobalFunction = (/** @type {Config} */ config, /** @type {Gr
 					delete style['@import']
 				}
 
-				let globalIndex = sheet.rules.global.group.cssRules.length
-
 				toCssRules(style, [], [], config, (cssText) => {
-					sheet.rules.global.group.insertRule(cssText, globalIndex++)
+					sheet.rules.global.apply(cssText)
 				})
 			}
 
@@ -47,6 +46,5 @@ export const createGlobalFunction = (/** @type {Config} */ config, /** @type {Gr
 
 		return define(render, {
 			toString: render,
-			[Symbol.toPrimitive]: render,
 		})
 	})

--- a/packages/core/src/features/keyframes.js
+++ b/packages/core/src/features/keyframes.js
@@ -21,15 +21,13 @@ export const createKeyframesFunction = (/** @type {Config} */ config, /** @type 
 			if (!sheet.rules.global.cache.has(name)) {
 				sheet.rules.global.cache.add(name)
 
-				let index = sheet.rules.global.group.cssRules.length
-
 				const cssRules = []
 
 				toCssRules(style, [], [], config, (cssText) => cssRules.push(cssText))
 
 				const cssText = `@keyframes ${name}{${cssRules.join('')}}`
 
-				sheet.rules.global.group.insertRule(cssText, index++)
+				sheet.rules.global.apply(cssText)
 			}
 
 			return name
@@ -40,7 +38,6 @@ export const createKeyframesFunction = (/** @type {Config} */ config, /** @type 
 				return render()
 			},
 			toString: render,
-			[Symbol.toPrimitive]: render,
 		})
 	})
 ) // prettier-ignore

--- a/packages/core/src/features/theme.js
+++ b/packages/core/src/features/theme.js
@@ -45,12 +45,10 @@ export const createThemeFunction = (/** @type {Config} */ config, /** @type {Gro
 			if (cssProps.length && !sheet.rules.themed.cache.has(className)) {
 				sheet.rules.themed.cache.add(className)
 
-				let index = sheet.rules.themed.group.cssRules.length
-
 				const rootPrelude = style === config.theme ? ':root,' : ''
 				const cssText = `${rootPrelude}.${className}{${cssProps.join(';')}}`
 
-				sheet.rules.themed.group.insertRule(cssText, index++)
+				sheet.rules.themed.apply(cssText)
 			}
 
 			return className
@@ -61,7 +59,6 @@ export const createThemeFunction = (/** @type {Config} */ config, /** @type {Gro
 			className,
 			selector,
 			toString: render,
-			[Symbol.toPrimitive]: render,
 		}
 	})
 ) // prettier-ignore


### PR DESCRIPTION
This changes the functionality for inserting new rules into the CSSOM so that they will not throw when an invalid rule is being added.