### PR TITLE
0.2.x — Fix hydrated rules inserted in the incorrect order after a reset

### DIFF
--- a/packages/core/src/createSheet.js
+++ b/packages/core/src/createSheet.js
@@ -217,7 +217,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 	const groupingRule = group.group
 
-	let index = 0
+	let index = groupingRule.cssRules.length
 
 	group.apply = (cssText) => {
 		try {


### PR DESCRIPTION
This change updates the internal style insertion method so that it inserts newer, dynamic rules over older, pre-rendered rules.

Resolves #635