### PR TITLE
0.2.x — Omit catch warning log on invalid rule

### DIFF
--- a/packages/core/src/createSheet.js
+++ b/packages/core/src/createSheet.js
@@ -224,8 +224,8 @@ const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 			groupingRule.insertRule(cssText, index)
 
 			++index
-		} catch (error) {
-			console.warn(error.message)
+		} catch {
+			// do nothing and continue
 		}
 	}
 }


### PR DESCRIPTION
This change removes the `console.warn` that can display when a dynamically inserted rule is unknown to the browser. In most scenarios, this is because the selector is unsupported in that particular browser, and tho the fallback is also included in the stylesheet, the unsupported rule will still log an unnecessary warning.

Resolves #637