### PR TITLE
0.2.x — Add a styled display name

### DIFF
--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -36,6 +36,7 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			const toString = () => cssComponent.selector
 
 			styledComponent.className = cssComponent.className
+			styledComponent.displayName = `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
 			styledComponent.selector = cssComponent.selector
 			styledComponent.type = DefaultType
 			styledComponent.toString = toString


### PR DESCRIPTION
This change adds a friendly display name to `styled` components, which can be useful in React Developer Tools and other debuggers.