### PR TITLE
v0.2.2

### DIFF
--- a/packages/core/src/createSheet.js
+++ b/packages/core/src/createSheet.js
@@ -224,8 +224,8 @@ const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 			groupingRule.insertRule(cssText, index)
 
 			++index
-		} catch (error) {
-			console.warn(error.message)
+		} catch {
+			// do nothing and continue
 		}
 	}
 }

--- a/packages/core/src/createSheet.js
+++ b/packages/core/src/createSheet.js
@@ -217,7 +217,7 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 	const groupingRule = group.group
 
-	let index = 0
+	let index = groupingRule.cssRules.length
 
 	group.apply = (cssText) => {
 		try {

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -36,6 +36,7 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			const toString = () => cssComponent.selector
 
 			styledComponent.className = cssComponent.className
+			styledComponent.displayName = `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
 			styledComponent.selector = cssComponent.selector
 			styledComponent.type = DefaultType
 			styledComponent.toString = toString


### PR DESCRIPTION
Beta Release: `0.2.2` 🚀 

- Fixed an issue where some dynamic could be inserted before hydrated styles. (#638)
- Removed a console warning when a dynamically inserted rule was not supported by that browser. (#639)
- Added a display name to `styled` components. (#640)
