### PR TITLE
0.2.x — rollback `token.name` to be `token.token`

### DIFF
--- a/packages/core/src/ThemeToken.d.ts
+++ b/packages/core/src/ThemeToken.d.ts
@@ -2,10 +2,10 @@ import { Optional, Primitive, ToString, ToTailDashed } from './utility'
 
 /** Theme Tokens represent named reusable values, which may be unique to a scale and prefixed. */
 export declare class ThemeToken<T1 extends Primitive, T2 extends Primitive, T3 extends Optional, T4 extends Optional> {
-	constructor(name: T1, value: T2, scale?: T3, prefix?: T4)
+	constructor(token: T1, value: T2, scale?: T3, prefix?: T4)
 
 	/** Name of the token. */
-	name: Primitive extends T1 ? '' : ToString<T1>
+	token: Primitive extends T1 ? '' : ToString<T1>
 
 	/** Original value of the token. */
 	value: Primitive extends T2 ? '' : `${T2}`
@@ -17,7 +17,7 @@ export declare class ThemeToken<T1 extends Primitive, T2 extends Primitive, T3 e
 	prefix: Optional extends T4 ? '' : `${T4}`
 
 	/** Serialized custom property representing the token. */
-	variable: `--${ToTailDashed<this['prefix']>}${ToTailDashed<this['scale']>}${this['name']}`
+	variable: `--${ToTailDashed<this['prefix']>}${ToTailDashed<this['scale']>}${this['token']}`
 
 	/** Serialized CSS var() representing the token. */
 	computedValue: `var(${this['variable']})`

--- a/packages/core/src/ThemeToken.js
+++ b/packages/core/src/ThemeToken.js
@@ -1,8 +1,8 @@
 import { toTailDashed } from './convert/toTailDashed.js'
 
 export class ThemeToken {
-	constructor(name, value, scale, prefix) {
-		this.name = name == null ? '' : String(name)
+	constructor(token, value, scale, prefix) {
+		this.token = token == null ? '' : String(token)
 		this.value = value == null ? '' : String(value)
 		this.scale = scale == null ? '' : String(scale)
 		this.prefix = prefix == null ? '' : String(prefix)
@@ -13,7 +13,7 @@ export class ThemeToken {
 	}
 
 	get variable() {
-		return '--' + toTailDashed(this.prefix) + toTailDashed(this.scale) + this.name
+		return '--' + toTailDashed(this.prefix) + toTailDashed(this.scale) + this.token
 	}
 
 	toString() {

--- a/packages/core/tests/universal-tokens.js
+++ b/packages/core/tests/universal-tokens.js
@@ -1,217 +1,209 @@
 import { createCss } from '../src/index.js'
 
 describe('Tokens', () => {
-	test('Authors can use a regular token', () => {
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					colors: {
-						red: 'tomato',
-					},
+	test('Authors can use a regular token #1', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				colors: {
+					red: 'tomato',
 				},
-			})
+			},
+		})
 
-			global({
-				article: {
-					color: '$red',
-				},
-			})()
+		global({
+			article: {
+				color: '$red',
+			},
+		})()
 
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-iknykm}@media{` +
-					`:root,.t-iknykm{--colors-red:tomato}` +
-				`}--stitches{--:1 fMIGFF}@media{` +
-					`article{color:var(--colors-red)}` +
-				`}`
-			)
-		}
-
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					shadows: {
-						red: 'tomato',
-					},
-				},
-			})
-
-			global({
-				article: {
-					boxShadow: '0 0 0 1px $red',
-				},
-			})()
-
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-daOLKV}@media{` +
-					`:root,.t-daOLKV{--shadows-red:tomato}` +
-				`}--stitches{--:1 bstpNq}@media{` +
-					`article{box-shadow:0 0 0 1px var(--shadows-red)}` +
-				`}`
-			)
-		}
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-iknykm}@media{` +
+				`:root,.t-iknykm{--colors-red:tomato}` +
+			`}--stitches{--:1 fMIGFF}@media{` +
+				`article{color:var(--colors-red)}` +
+			`}`
+		)
 	})
 
-	test('Authors can use a relative token', () => {
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					colors: {
-						red: 'tomato',
-						red500: '$red',
-					},
+	test('Authors can use a regular token #2', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				shadows: {
+					red: 'tomato',
 				},
-			})
+			},
+		})
 
-			global({
-				article: {
-					color: '$red500',
-				},
-			})()
+		global({
+			article: {
+				boxShadow: '0 0 0 1px $red',
+			},
+		})()
 
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-eZaaph}@media{` +
-					`:root,.t-eZaaph{--colors-red:tomato;--colors-red500:var(--colors-red)}` +
-				`}--stitches{--:1 fdgxsg}@media{` +
-					`article{color:var(--colors-red500)}` +
-				`}`
-			)
-		}
-
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					shadows: {
-						red: 'tomato',
-						red500: '$red',
-						redUnique: '$$red'
-					},
-				},
-			})
-
-			global({
-				article: {
-					boxShadow: '0 0 0 1px $red500',
-				},
-			})()
-
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-gxqihb}@media{` +
-					`:root,.t-gxqihb{--shadows-red:tomato;--shadows-red500:var(--shadows-red);--shadows-redUnique:var(---red)}` +
-				`}` +
-				`--stitches{--:1 kyFUgb}@media{` +
-					`article{box-shadow:0 0 0 1px var(--shadows-red500)}` +
-				`}`
-			)
-		}
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-daOLKV}@media{` +
+				`:root,.t-daOLKV{--shadows-red:tomato}` +
+			`}--stitches{--:1 bstpNq}@media{` +
+				`article{box-shadow:0 0 0 1px var(--shadows-red)}` +
+			`}`
+		)
 	})
 
-	test('Authors can use an absolute token', () => {
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					colors: {
-						red: 'tomato',
-					},
+	test('Authors can use a relative token #1', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				colors: {
+					red: 'tomato',
+					red500: '$red',
 				},
-			})
+			},
+		})
 
-			global({
-				article: {
-					boxShadow: '0 0 0 1px $colors$red',
-				},
-			})()
+		global({
+			article: {
+				color: '$red500',
+			},
+		})()
 
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-iknykm}@media{` +
-					`:root,.t-iknykm{--colors-red:tomato}` +
-				`}` +
-				`--stitches{--:1 hNRkrs}@media{` +
-					`article{box-shadow:0 0 0 1px var(--colors-red)}` +
-				`}`
-			)
-		}
-
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					colors: {
-						red: 'tomato',
-					},
-				},
-			})
-
-			global({
-				article: {
-					boxShadow: '0 0 0 1px $colors$red',
-				},
-			})()
-
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-iknykm}@media{` +
-					`:root,.t-iknykm{--colors-red:tomato}` +
-				`}` +
-				`--stitches{--:1 hNRkrs}@media{` +
-					`article{box-shadow:0 0 0 1px var(--colors-red)}` +
-				`}`
-			)
-		}
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-eZaaph}@media{` +
+				`:root,.t-eZaaph{--colors-red:tomato;--colors-red500:var(--colors-red)}` +
+			`}--stitches{--:1 fdgxsg}@media{` +
+				`article{color:var(--colors-red500)}` +
+			`}`
+		)
 	})
 
-	test('Authors can use a negative token', () => {
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					space: {
-						sp1: '100px',
-						sp2: '200px',
-					},
+	test('Authors can use a relative token #1', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				shadows: {
+					red: 'tomato',
+					red500: '$red',
+					redUnique: '$$red'
 				},
-			})
+			},
+		})
 
-			global({
-				article: {
-					marginLeft: '-$sp1',
-					marginTop: '-$sp2',
+		global({
+			article: {
+				boxShadow: '0 0 0 1px $red500',
+			},
+		})()
+
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-gxqihb}@media{` +
+				`:root,.t-gxqihb{--shadows-red:tomato;--shadows-red500:var(--shadows-red);--shadows-redUnique:var(---red)}` +
+			`}` +
+			`--stitches{--:1 kyFUgb}@media{` +
+				`article{box-shadow:0 0 0 1px var(--shadows-red500)}` +
+			`}`
+		)
+	})
+
+	test('Authors can use an absolute token #1', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				colors: {
+					red: 'tomato',
 				},
-			})()
+			},
+		})
 
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-hxjLZl}@media{` +
-					`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
-				`}` +
-				`--stitches{--:1 kTSGli}@media{` +
-					`article{margin-left:calc(var(--space-sp1)*-1);margin-top:calc(var(--space-sp2)*-1)}` +
-				`}`
-			)
-		}
+		global({
+			article: {
+				boxShadow: '0 0 0 1px $colors$red',
+			},
+		})()
 
-		{
-			const { global, getCssString } = createCss({
-				theme: {
-					sizes: {
-						sp1: '10px',
-						sp2: '20px',
-						sp3: '30px',
-					},
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-iknykm}@media{` +
+				`:root,.t-iknykm{--colors-red:tomato}` +
+			`}` +
+			`--stitches{--:1 hNRkrs}@media{` +
+				`article{box-shadow:0 0 0 1px var(--colors-red)}` +
+			`}`
+		)
+	})
+
+	test('Authors can use an absolute token #2', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				colors: {
+					red: 'tomato',
 				},
-			})
+			},
+		})
 
-			global({
-				article: {
-					marginLeft: '-$sizes$sp1',
-					width: '$sp1',
+		global({
+			article: {
+				boxShadow: '0 0 0 1px $colors$red',
+			},
+		})()
+
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-iknykm}@media{` +
+				`:root,.t-iknykm{--colors-red:tomato}` +
+			`}` +
+			`--stitches{--:1 hNRkrs}@media{` +
+				`article{box-shadow:0 0 0 1px var(--colors-red)}` +
+			`}`
+		)
+	})
+
+	test('Authors can use a negative token #1', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				space: {
+					sp1: '100px',
+					sp2: '200px',
 				},
-			})()
+			},
+		})
 
-			expect(getCssString()).toBe(
-				`--stitches{--:0 t-ereMzu}@media{` +
-					`:root,.t-ereMzu{--sizes-sp1:10px;--sizes-sp2:20px;--sizes-sp3:30px}` +
-				`}` +
-				`--stitches{--:1 kuTEdV}@media{` +
-					`article{margin-left:calc(var(--sizes-sp1)*-1);width:var(--sizes-sp1)}` +
-				`}`
-			)
-		}
+		global({
+			article: {
+				marginLeft: '-$sp1',
+				marginTop: '-$sp2',
+			},
+		})()
+
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-hxjLZl}@media{` +
+				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
+			`}` +
+			`--stitches{--:1 kTSGli}@media{` +
+				`article{margin-left:calc(var(--space-sp1)*-1);margin-top:calc(var(--space-sp2)*-1)}` +
+			`}`
+		)
+	})
+
+	test('Authors can use a negative token #2', () => {
+		const { global, getCssString } = createCss({
+			theme: {
+				sizes: {
+					sp1: '10px',
+					sp2: '20px',
+					sp3: '30px',
+				},
+			},
+		})
+
+		global({
+			article: {
+				marginLeft: '-$sizes$sp1',
+				width: '$sp1',
+			},
+		})()
+
+		expect(getCssString()).toBe(
+			`--stitches{--:0 t-ereMzu}@media{` +
+				`:root,.t-ereMzu{--sizes-sp1:10px;--sizes-sp2:20px;--sizes-sp3:30px}` +
+			`}` +
+			`--stitches{--:1 kuTEdV}@media{` +
+				`article{margin-left:calc(var(--sizes-sp1)*-1);width:var(--sizes-sp1)}` +
+			`}`
+		)
 	})
 
 	test('Authors can use tokens from the global theme object', () => {
@@ -235,7 +227,7 @@ describe('Tokens', () => {
 			`--stitches{--:0 t-hxjLZl}@media{` +
 				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
 			`}` +
-			`--stitches{--:1 ejuGBl}@media{` +
+			`--stitches{--:1 lcIUgV}@media{` +
 				`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}` +
 			`}`
 		)
@@ -259,7 +251,7 @@ describe('Tokens', () => {
 		})()
 
 		expect(getCssString()).toBe(
-			`--stitches{--:1 ejuGBl}@media{article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}}`,
+			`--stitches{--:1 lcIUgV}@media{article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}}`,
 		)
 
 		void `${mytheme}`
@@ -267,7 +259,7 @@ describe('Tokens', () => {
 		expect(getCssString()).toBe(
 			`--stitches{--:0 my-theme}@media{` +
 				`.my-theme{--space-sp1:100px;--space-sp2:200px}` +
-			`}--stitches{--:1 ejuGBl}@media{` +
+			`}--stitches{--:1 lcIUgV}@media{` +
 				`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}` +
 			`}`
 		)
@@ -294,7 +286,7 @@ describe('Tokens', () => {
 			`--stitches{--:0 t-hxjLZl}@media{` +
 				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
 			`}` +
-			`--stitches{--:1 ejuGBl}@media{` +
+			`--stitches{--:1 lcIUgV}@media{` +
 				`article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}` +
 			`}`
 		)


### PR DESCRIPTION
This change switches `Token#name` back to `Token#token`, as it was in Stitches 0.1.x.

See https://github.com/modulz/stitches/issues/643