### PR TITLE
0.2.x — Expand `peerDependency` for `react` to include v16

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "react": "17.0.2"
   },
   "peerDependencies": {
-    "react": ">= 16"
+    "react": ">= 16.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "react": "17.0.2"
   },
   "peerDependencies": {
-    "react": ">= 17.0.0"
+    "react": ">= 16"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This change expands the `peerDependency` coverage for `react` from `>= 17` to `>= 16`.

Resolves https://github.com/modulz/stitches/discussions/647