### PR TITLE
Fix issue with default variants not applying during composition

### DIFF
--- a/packages/core/src/features/css.js
+++ b/packages/core/src/features/css.js
@@ -320,7 +320,8 @@ const getPreparedDataFromComposers = (/** @type {Set<Composer>} */ composers) =>
 		combinedUndefinedVariants.push(...undefinedVariants)
 
 		for (const name in prefilledVariants) {
-			combinedPrefilledVariants[name] = prefilledVariants[name]
+			const data = prefilledVariants[name]
+			if (combinedPrefilledVariants[name] === undefined || data !== 'undefined' || undefinedVariants.includes(data)) combinedPrefilledVariants[name] = data
 		}
 	}
 

--- a/packages/core/tests/issue-652.js
+++ b/packages/core/tests/issue-652.js
@@ -1,0 +1,34 @@
+import { createCss } from '../src/index.js'
+
+describe('Issue #652', () => {
+	test('Applying both variants from the one default variant', () => {
+		const { css } = createCss()
+
+		const component1 = css({
+			variants: {
+				hue: {
+					primary: {
+						color: 'red',
+					},
+				},
+			},
+			defaultVariants: {
+				hue: 'primary',
+			},
+		})
+
+		const component2 = css(component1, {
+			variants: {
+				hue: {
+					primary: {
+						color: 'blue',
+					},
+				},
+			},
+		})
+
+		const expression2 = component2()
+
+		expect(expression2.className).toBe(`c-PJLV c-PJLV-gmqXFB-hue-primary c-PJLV-kydkiA-hue-primary`)
+	})
+})


### PR DESCRIPTION
This PR changes how default variants are spread across compositions, allowing them to spread much more intuitively.

Resolves #652