### PR TITLE
#675 Fix className Composition

### DIFF
--- a/packages/core/src/features/css.js
+++ b/packages/core/src/features/css.js
@@ -147,13 +147,13 @@ const createRenderer = (
 	/** @type {import('../createSheet').SheetGroup} */ sheet
 ) => {
 	const [
-		initialClassName,
+		latestClassName,
 		baseClassNames,
 		prefilledVariants,
 		undefinedVariants
 	] = getPreparedDataFromComposers(composers)
 
-	const selector = `.${initialClassName}`
+	const selector = `.${latestClassName}`
 
 	/** @type {Render} */
 	const render = (props) => {
@@ -254,7 +254,7 @@ const createRenderer = (
 		// apply css property styles
 		if (typeof css === 'object' && css) {
 			/** @type {string} Inline Class Unique Identifier. @see `{COMPOSER_UUID}-i{VARIANT_UUID}-css` */
-			const iClass = `${initialClassName}-i${toHash(css)}-css`
+			const iClass = `${latestClassName}-i${toHash(css)}-css`
 
 			classSet.add(iClass)
 
@@ -285,13 +285,13 @@ const createRenderer = (
 	}
 
 	const toString = () => {
-		if (!sheet.rules.styled.cache.has(initialClassName)) render()
-		return initialClassName
+		if (!sheet.rules.styled.cache.has(latestClassName)) render()
+		return latestClassName
 	}
 
 	return define(render, {
 		type,
-		className: initialClassName,
+		className: latestClassName,
 		selector,
 		[$$composers]: composers,
 		toString,
@@ -301,7 +301,7 @@ const createRenderer = (
 /** Returns useful data that can be known before rendering. */
 const getPreparedDataFromComposers = (/** @type {Set<Composer>} */ composers) => {
 	/** Class name of the first composer. */
-	let initialClassName = ''
+	let latestClassName = ''
 
 	/** @type {string[]} Combined class names for all composers. */
 	const combinedClassNames = []
@@ -313,7 +313,7 @@ const getPreparedDataFromComposers = (/** @type {Set<Composer>} */ composers) =>
 	const combinedUndefinedVariants = []
 
 	for (const [className, , , , prefilledVariants, undefinedVariants] of composers) {
-		if (initialClassName === '') initialClassName = className
+		latestClassName = className
 
 		combinedClassNames.push(className)
 
@@ -327,7 +327,7 @@ const getPreparedDataFromComposers = (/** @type {Set<Composer>} */ composers) =>
 
 	/** @type {[string, string[], PrefilledVariants, Set<UndefinedVariants>]} */
 	const preparedData = [
-		initialClassName,
+		latestClassName,
 		combinedClassNames,
 		combinedPrefilledVariants,
 		new Set(combinedUndefinedVariants)

--- a/packages/core/tests/component-composition.js
+++ b/packages/core/tests/component-composition.js
@@ -16,9 +16,9 @@ describe('Composition', () => {
 		const bold = css({ fontWeight: 'bold' })
 		const title = css(red, size14, bold, { fontFamily: 'monospace' })
 
-		expect(title.className).toBe('c-gmqXFB')
+		expect(title.className).toBe('c-kngyIZ')
 		expect(toString()).toBe('')
-		expect(String(title)).toBe('c-gmqXFB')
+		expect(String(title)).toBe('c-kngyIZ')
 		expect(toString()).toBe(
 			`--stitches{--:2 c-gmqXFB c-hzkWus c-cQFdVt c-kngyIZ}@media{` +
 				`.c-gmqXFB{color:red}` +

--- a/packages/core/tests/component-styled-composition.js
+++ b/packages/core/tests/component-styled-composition.js
@@ -1,0 +1,33 @@
+import { createCss } from '../src/index.js'
+
+describe('Composition', () => {
+	test('Renders an empty component', () => {
+		const { css, toString } = createCss()
+		const generic = css()
+
+		expect(generic().props).toEqual({ className: 'PJLV' })
+		expect(toString()).toBe('')
+	})
+
+	test('Renders composed styles with their own classes', () => {
+		const { css, toString } = createCss()
+		const box = css({ borderSizing: 'border-box' })
+		const flex = css(box, { display: 'flex' })
+		const row = css(flex, { flexDirection: 'row' })
+		expect(box.className).toBe('c-hkrHCb')
+		expect(flex.className).toBe('c-dhzjXW')
+		expect(row.className).toBe('c-ejCoEP')
+
+		const title = css(box, flex, row, { background: 'red' })
+		expect(title().className).toBe('c-hkrHCb c-dhzjXW c-ejCoEP c-elTJue')
+		expect(toString()).toBe(`
+			--stitches{--:2 c-hkrHCb c-dhzjXW c-ejCoEP c-elTJue}
+			@media{
+				.c-hkrHCb{border-sizing:border-box}
+				.c-dhzjXW{display:flex}
+				.c-ejCoEP{flex-direction:row}
+				.c-elTJue{background:red}
+			}
+		`.replace(/[\f\n\r\t\v]/g, ''))
+	})
+}) // prettier-ignore

--- a/packages/react/tests/component-composition.js
+++ b/packages/react/tests/component-composition.js
@@ -14,7 +14,7 @@ describe('Composition', () => {
 		const size14 = styled({ fontSize: '14px' })
 		const bold = styled({ fontWeight: 'bold' })
 		const title = styled(red, size14, bold, { fontFamily: 'monospace' })
-		expect(`${title}`).toBe('.c-gmqXFB')
+		expect(`${title}`).toBe('.c-kngyIZ')
 		expect(getCssString()).toBe('')
 	})
 

--- a/packages/react/tests/component-styled-composition.js
+++ b/packages/react/tests/component-styled-composition.js
@@ -1,0 +1,32 @@
+import { createCss } from '../src/index.js'
+
+describe('Composition', () => {
+	test('Renders an empty component', () => {
+		const { styled, getCssString } = createCss()
+		const generic = styled()
+		expect(generic.render().props).toEqual({ className: 'PJLV' })
+		expect(getCssString()).toBe('')
+	})
+
+	test('Renders composed styled components with their own classes', () => {
+		const { styled, getCssString } = createCss()
+		const Box = styled({ borderSizing: 'border-box' })
+		const Flex = styled(Box, { display: 'flex' })
+		const Row = styled(Flex, { flexDirection: 'row' })
+		expect(Box.className).toBe('c-hkrHCb')
+		expect(Flex.className).toBe('c-dhzjXW')
+		expect(Row.className).toBe('c-ejCoEP')
+
+		const Title = styled(Box, Flex, Row, { background: 'red' })
+		expect(Title.render().props.className).toBe('c-hkrHCb c-dhzjXW c-ejCoEP c-elTJue')
+		expect(getCssString()).toBe(`
+			--stitches{--:2 c-hkrHCb c-dhzjXW c-ejCoEP c-elTJue}
+			@media{
+				.c-hkrHCb{border-sizing:border-box}
+				.c-dhzjXW{display:flex}
+				.c-ejCoEP{flex-direction:row}
+				.c-elTJue{background:red}
+			}
+		`.replace(/[\f\n\r\t\v]/g, ''))
+	})
+})


### PR DESCRIPTION
# Description

Addresses issue #675: `className` sticks to initial component, when composing Stitches-styled components.

**NOTE 1**: I renamed `initialClassName` to `latestClassName`, to reflect the change in line 316 of `css.js`, but the only functional change is the one to line 316.

**NOTE 2**: I don't have full context on why `initialClassName` was being used for chaining of class names; switching to `latestClassName` definitely addresses the issue above, but I'm not sure if it could have unintended consequences, due to my lack of context here.