### PR TITLE
rename: `getCssString` to `getCssText`

### DIFF
--- a/packages/core/src/createStitches.js
+++ b/packages/core/src/createStitches.js
@@ -54,7 +54,7 @@ export const createStitches = (config) => {
 			sheet,
 			config,
 			prefix,
-			getCssString: sheet.toString,
+			getCssText: sheet.toString,
 			toString: sheet.toString,
 		}
 

--- a/packages/core/tests/basic.js
+++ b/packages/core/tests/basic.js
@@ -11,18 +11,18 @@ describe('Basic', () => {
 		expect(stitches.createTheme).toBeInstanceOf(Function)
 	})
 
-	test('Functionality of getCssString()', () => {
-		const { getCssString } = createStitches()
+	test('Functionality of getCssText()', () => {
+		const { getCssText } = createStitches()
 
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Functionality of css()', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of2 = css()
 		const className1of2 = `${component1of2}`
-		const cssString1of2 = getCssString()
+		const cssString1of2 = getCssText()
 
 		expect(component1of2).toBeInstanceOf(Function)
 		expect(className1of2).toBe('PJLV')
@@ -30,7 +30,7 @@ describe('Basic', () => {
 
 		const component2of2 = css({ color: 'DodgerBlue' })
 		const className2of2 = `${component2of2}`
-		const cssString2of2 = getCssString()
+		const cssString2of2 = getCssText()
 
 		expect(component2of2).toBeInstanceOf(Function)
 		expect(className2of2).toBe('c-dataoT')
@@ -38,23 +38,23 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of reset()', () => {
-		const { reset, getCssString } = createStitches()
+		const { reset, getCssText } = createStitches()
 
 		expect(reset).toBeInstanceOf(Function)
 
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 
 		reset()
 
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Functionality of globalCss()', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		const rendering1of2 = globalCss()
 		const className1of2 = `${rendering1of2}`
-		const cssString1of2 = getCssString()
+		const cssString1of2 = getCssText()
 
 		expect(rendering1of2).toBeInstanceOf(Function)
 		expect(className1of2).toBe('')
@@ -62,7 +62,7 @@ describe('Basic', () => {
 
 		const rendering2of2 = globalCss({ body: { margin: 0 } })
 		const className2of2 = `${rendering2of2}`
-		const cssString2of2 = getCssString()
+		const cssString2of2 = getCssText()
 
 		expect(rendering2of2).toBeInstanceOf(Function)
 		expect(className2of2).toBe('')
@@ -70,7 +70,7 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of keyframes()', () => {
-		const { keyframes, getCssString } = createStitches()
+		const { keyframes, getCssText } = createStitches()
 
 		const rendering1of1 = keyframes({
 			'0%': {
@@ -81,7 +81,7 @@ describe('Basic', () => {
 			},
 		})
 		const className1of1 = `${rendering1of1}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(rendering1of1).toBeInstanceOf(Function)
 		expect(className1of1).toBe('k-jOrSYg')
@@ -89,7 +89,7 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of createTheme()', () => {
-		const { createTheme, getCssString } = createStitches()
+		const { createTheme, getCssText } = createStitches()
 
 		const rendering1of1 = createTheme({
 			colors: {
@@ -99,7 +99,7 @@ describe('Basic', () => {
 		})
 
 		const className1of1 = `${rendering1of1}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(rendering1of1).toBeInstanceOf(Object)
 		expect(className1of1).toBe('t-kfidiM')
@@ -107,11 +107,11 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of css() — css prop', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of1 = css({ color: 'DodgerBlue' })
 		const className1of1 = `${component1of1({ css: { color: 'Crimson' } })}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(component1of1).toBeInstanceOf(Function)
 		expect(className1of1).toBe('c-dataoT c-dataoT-icaIZdx-css')
@@ -126,7 +126,7 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of css() — variants', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of1 = css({
 			fontSize: '100%',
@@ -142,7 +142,7 @@ describe('Basic', () => {
 			},
 		})
 		const className1of1 = `${component1of1({ shade: 'red' })}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(component1of1).toBeInstanceOf(Function)
 		expect(className1of1).toBe('c-imTdEZ c-imTdEZ-caIZdx-shade-red')
@@ -150,7 +150,7 @@ describe('Basic', () => {
 	})
 
 	test('Functionality of css() — utils', () => {
-		const { css, getCssString } = createStitches({
+		const { css, getCssText } = createStitches({
 			utils: {
 				userSelect: (value) => ({
 					WebkitUserSelector: value,
@@ -163,41 +163,41 @@ describe('Basic', () => {
 			userSelect: 'none',
 		})
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('c-bStdfw')
 		expect(cssString1of1).toBe(`--stitches{--:2 c-bStdfw}@media{.c-bStdfw{-webkit-user-selector:none;user-select:none}}`)
 	})
 
 	test('Functionality of stringification — numeric pixel values', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of1 = css({
 			width: 100,
 		})
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('c-eBcQxc')
 		expect(cssString1of1).toBe(`--stitches{--:2 c-eBcQxc}@media{.c-eBcQxc{width:100px}}`)
 	})
 
 	test('Functionality of stringification — token values', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of1 = css({
 			width: '$brand',
 		})
 
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('c-lpaZZu')
 		expect(cssString1of1).toBe(`--stitches{--:2 c-lpaZZu}@media{.c-lpaZZu{width:var(--sizes-brand)}}`)
 	})
 
 	test('Functionality of stringification — local tokens', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component1of1 = css({
 			$$brand: '500px',
@@ -205,14 +205,14 @@ describe('Basic', () => {
 		})
 
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('c-elRGCe')
 		expect(cssString1of1).toBe(`--stitches{--:2 c-elRGCe}@media{.c-elRGCe{---brand:500px;width:var(---brand)}}`)
 	})
 
 	test('Functionality of stringification — local tokens prefixed', () => {
-		const { css, getCssString } = createStitches({
+		const { css, getCssText } = createStitches({
 			prefix: 'fusion',
 		})
 
@@ -222,14 +222,14 @@ describe('Basic', () => {
 		})
 
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('fusion-c-elRGCe')
 		expect(cssString1of1).toBe(`--stitches{--:2 fusion-c-elRGCe}@media{.fusion-c-elRGCe{--fusion--brand:500px;width:var(--fusion--brand)}}`)
 	})
 
 	test('Stringification: Utils + Local Tokens', () => {
-		const { css, getCssString } = createStitches({
+		const { css, getCssText } = createStitches({
 			utils: {
 				backdropFilter: (value) => ({
 					WebkitBackdropFilter: value,
@@ -244,14 +244,14 @@ describe('Basic', () => {
 		})
 
 		const className1of1 = `${component1of1()}`
-		const cssString1of1 = getCssString()
+		const cssString1of1 = getCssText()
 
 		expect(className1of1).toBe('c-brAtkJ')
 		expect(cssString1of1).toBe(`--stitches{--:2 c-brAtkJ}@media{.c-brAtkJ{---blur:test;-webkit-backdrop-filter:var(---blur);backdrop-filter:var(---blur)}}`)
 	})
 
 	test('Theme', () => {
-		const { getCssString } = createStitches({
+		const { getCssText } = createStitches({
 			theme: {
 				colors: {
 					red: 'Crimson',
@@ -260,6 +260,6 @@ describe('Basic', () => {
 			},
 		})
 
-		expect(getCssString()).toBe(`--stitches{--:0 t-kfidiM}@media{:root,.t-kfidiM{--colors-red:Crimson;--colors-blue:DodgerBlue}}`)
+		expect(getCssText()).toBe(`--stitches{--:0 t-kfidiM}@media{:root,.t-kfidiM{--colors-red:Crimson;--colors-blue:DodgerBlue}}`)
 	})
 }) // prettier-ignore

--- a/packages/core/tests/component-empty-variants.js
+++ b/packages/core/tests/component-empty-variants.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Empty Variants', () => {
 	test('Empty Variants', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			variants: {
@@ -24,11 +24,11 @@ describe('Empty Variants', () => {
 			size: { '@initial': 'xl' },
 		})
 
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Empty Variants', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			variants: {
@@ -51,7 +51,7 @@ describe('Empty Variants', () => {
 			size: { '@initial': 'xl' },
 		})
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:4 c-PJLV-lhHHWD-cv}@media{` +
 				`.c-PJLV-lhHHWD-cv{font-size:24px;color:black}` +
 			`}`

--- a/packages/core/tests/component-variants.js
+++ b/packages/core/tests/component-variants.js
@@ -42,34 +42,34 @@ describe('Variants', () => {
 	}
 
 	test('Renders a component without any initial styles', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component()
 
 		expect(expression.className).toBe('c-PJLV')
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Renders a component with 1 matching variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression1 = component({ size: 'small' })
 
 		const expression1CssText = '.c-PJLV-Gaggi-size-small{font-size:16px}'
 
 		expect(expression1.className).toBe('c-PJLV c-PJLV-Gaggi-size-small')
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{${expression1CssText}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{${expression1CssText}}`)
 
 		const expression2 = component({ color: 'blue' })
 
 		const expression2CssText = '.c-PJLV-kaCQqN-color-blue{background-color:dodgerblue;color:white}'
 
 		expect(expression2.className).toBe('c-PJLV c-PJLV-kaCQqN-color-blue')
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small c-PJLV-kaCQqN-color-blue}@media{${expression1CssText + expression2CssText}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small c-PJLV-kaCQqN-color-blue}@media{${expression1CssText + expression2CssText}}`)
 	})
 
 	test('Renders a component with 2 matching variants', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css({
 			variants: {
 				size: {
@@ -97,11 +97,11 @@ describe('Variants', () => {
 		const expressionSizeSmallCssText = '.c-PJLV-Gaggi-size-small{font-size:16px}'
 		const expressionLevel1CssText = '.c-PJLV-iRwLiB-level-1{padding:0.5em}'
 
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small c-PJLV-iRwLiB-level-1}@media{${expressionSizeSmallCssText + expressionLevel1CssText}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small c-PJLV-iRwLiB-level-1}@media{${expressionSizeSmallCssText + expressionLevel1CssText}}`)
 	})
 
 	test('Renders a component with a 2 matching variants and 1 matching compound', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component({ size: 'small', color: 'blue' })
 
@@ -110,7 +110,7 @@ describe('Variants', () => {
 		const expressionCompoundCssText = '.c-PJLV-cChFtv-cv{transform:scale(1.2)}'
 
 		expect(expression.className).toBe(`c-PJLV c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small c-PJLV-cChFtv-cv`)
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small}@media{${
 				expressionColorBlueCssText + expressionSizeSmallCssText
 			}}--stitches{--:4 c-PJLV-cChFtv-cv}@media{${
@@ -165,39 +165,39 @@ describe('Variants with defaults', () => {
 	}
 
 	test('Renders a component with the default variant applied', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component()
 
 		expect(expression.className).toBe('c-PJLV c-PJLV-Gaggi-size-small')
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}`)
 	})
 
 	test('Renders a component with the default variant explicitly applied', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component({ size: 'small' })
 
 		expect(expression.className).toBe('c-PJLV c-PJLV-Gaggi-size-small')
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}`)
 	})
 
 	test('Renders a component with the non-default variant explicitly applied', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component({ size: 'large' })
 
 		expect(expression.className).toBe('c-PJLV c-PJLV-hsYHIj-size-large')
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-hsYHIj-size-large}@media{.c-PJLV-hsYHIj-size-large{font-size:24px}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-hsYHIj-size-large}@media{.c-PJLV-hsYHIj-size-large{font-size:24px}}`)
 	})
 
 	test('Renders a component with the default variant applied and a different variant explicitly applied', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component({ level: 1 })
 
 		expect(expression.className).toBe('c-PJLV c-PJLV-Gaggi-size-small c-PJLV-iRwLiB-level-1')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-Gaggi-size-small c-PJLV-iRwLiB-level-1}@media{` +
 				// implicit size:small
 				`.c-PJLV-Gaggi-size-small{font-size:16px}` +
@@ -208,12 +208,12 @@ describe('Variants with defaults', () => {
 	})
 
 	test('Renders a component with the default variant applied, a different variant explicitly applied, and a compound applied', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const expression = component({ color: 'blue' })
 
 		expect(expression.className).toBe('c-PJLV c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small c-PJLV-cChFtv-cv')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small}@media{` +
 				// explicit color:blue
 				`.c-PJLV-kaCQqN-color-blue{background-color:dodgerblue;color:white}` +
@@ -227,12 +227,12 @@ describe('Variants with defaults', () => {
 	})
 
 	test('Returns a component class without the default variant applied when stringified', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfig)
 		const className = `${component}`
 
 		expect(className).toBe('c-PJLV')
-		expect(getCssString()).toBe('--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}')
+		expect(getCssText()).toBe('--stitches{--:3 c-PJLV-Gaggi-size-small}@media{.c-PJLV-Gaggi-size-small{font-size:16px}}')
 	})
 }) // prettier-ignore
 
@@ -286,31 +286,31 @@ describe('Conditional variants', () => {
 	}
 
 	test('Renders a component with no variant applied', () => {
-		const { css, getCssString } = createStitches(config)
+		const { css, getCssText } = createStitches(config)
 		const component = css(componentConfig)
 		const componentClassName = 'c-PJLV'
 
 		expect(component().className).toBe(componentClassName)
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Renders a component with one variant applied', () => {
-		const { css, getCssString } = createStitches(config)
+		const { css, getCssText } = createStitches(config)
 		const component = css(componentConfig)
 		const componentClassName = `c-PJLV`
 		const componentSmallClassName = `${componentClassName}-Gaggi-size-small`
 		const componentSmallCssText = `.${componentSmallClassName}{font-size:16px}`
 
 		expect(component({ size: 'small' }).className).toBe([componentClassName, componentSmallClassName].join(' '))
-		expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{${componentSmallCssText}}`)
+		expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-Gaggi-size-small}@media{${componentSmallCssText}}`)
 	})
 
 	test('Renders a component with one conditional variant on one breakpoint applied', () => {
-		const { css, getCssString } = createStitches(config)
+		const { css, getCssText } = createStitches(config)
 		const component = css(componentConfig)
 
 		expect(component({ size: { '@bp1': 'small' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small`)
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-iVKIeV-size-small}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 			`}`
@@ -318,7 +318,7 @@ describe('Conditional variants', () => {
 	})
 
 	test('Renders a component with one conditional variant on two breakpoints applied', () => {
-		const { css, getCssString } = createStitches(config)
+		const { css, getCssText } = createStitches(config)
 		const component = css(componentConfig)
 		const componentClassName = `c-PJLV`
 		const componentSmallBp1ClassName = `${componentClassName}-iVKIeV-size-small`
@@ -327,7 +327,7 @@ describe('Conditional variants', () => {
 		const componentLargeBp2CssText = `@media (min-width: 768px){.${componentLargeBp2ClassName}{font-size:24px}}`
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe([componentClassName, componentSmallBp1ClassName, componentLargeBp2ClassName].join(' '))
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				componentSmallBp1CssText +
 				componentLargeBp2CssText +
@@ -336,11 +336,11 @@ describe('Conditional variants', () => {
 	})
 
 	test('Renders a component with a conditional variant repeatedly', () => {
-		const { css, getCssString } = createStitches(config)
+		const { css, getCssText } = createStitches(config)
 		const component = css(componentConfig)
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
@@ -348,7 +348,7 @@ describe('Conditional variants', () => {
 		)
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
@@ -356,7 +356,7 @@ describe('Conditional variants', () => {
 		)
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
@@ -366,7 +366,7 @@ describe('Conditional variants', () => {
 
 	test('Renders a component with a conditional inline variant repeatedly', () => {
 		{
-			const { css, getCssString } = createStitches(config)
+			const { css, getCssText } = createStitches(config)
 			const component = css({
 				variants: {
 					size: {
@@ -389,7 +389,7 @@ describe('Conditional variants', () => {
 				}).className,
 			).toBe('c-PJLV c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large')
 
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:3 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
 					`@media (max-width:767.9375px){.c-PJLV-gjWYHE-size-small{font-size:16px}}` +
 					`@media (min-width:768px){.c-PJLV-fzmUzy-size-large{font-size:24px}}` +
@@ -398,7 +398,7 @@ describe('Conditional variants', () => {
 		}
 
 		{
-			const { css, getCssString } = createStitches(config)
+			const { css, getCssText } = createStitches(config)
 			const component = css({
 				variants: {
 					size: {
@@ -421,7 +421,7 @@ describe('Conditional variants', () => {
 				}).className,
 			).toBe('c-PJLV c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large')
 
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:3 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
 					`@media (max-width:767.9375px){.c-PJLV-gjWYHE-size-small{font-size:16px}}` +
 					`@media (min-width:768px){.c-PJLV-fzmUzy-size-large{font-size:24px}}` +
@@ -447,23 +447,23 @@ describe('Variant pairing types', () => {
 	}
 
 	test('Renders a variant with an inactive string variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfigForBooleanVariant)
 		const rendering = component()
 
 		expect(rendering.className).toBe('c-foEXqW')
-		expect(getCssString()).toBe(`--stitches{--:2 c-foEXqW}@media{` +
+		expect(getCssText()).toBe(`--stitches{--:2 c-foEXqW}@media{` +
 			`.c-foEXqW{--component:true}` +
 		`}`)
 	})
 
 	test('Renders a variant with an active string variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfigForBooleanVariant)
 		const rendering = component({ testBoolean: 'true' })
 
 		expect(rendering.className).toBe('c-foEXqW c-foEXqW-iloXEi-testBoolean-true')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +
@@ -474,12 +474,12 @@ describe('Variant pairing types', () => {
 	})
 
 	test('Renders a variant with an active boolean variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfigForBooleanVariant)
 		const rendering = component({ testBoolean: true })
 
 		expect(rendering.className).toBe('c-foEXqW c-foEXqW-iloXEi-testBoolean-true')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +
@@ -490,12 +490,12 @@ describe('Variant pairing types', () => {
 	})
 
 	test('Renders a variant with an active responsive string variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfigForBooleanVariant)
 		const rendering = component({ testBoolean: { '@media (min-width: 640px)': 'true' } })
 
 		expect(rendering.className).toBe('c-foEXqW c-foEXqW-brOaTK-testBoolean-true')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +
@@ -508,12 +508,12 @@ describe('Variant pairing types', () => {
 	})
 
 	test('Renders a variant with an active responsive boolean variant', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 		const component = css(componentConfigForBooleanVariant)
 		const rendering = component({ testBoolean: { '@media (min-width: 640px)': true } })
 
 		expect(rendering.className).toBe('c-foEXqW c-foEXqW-brOaTK-testBoolean-true')
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +

--- a/packages/core/tests/global-atrules.js
+++ b/packages/core/tests/global-atrules.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Support @import', () => {
 	test('Authors can define an @import rule', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		const importURL = `https://unpkg.com/sanitize.css@12.0.1/sanitize.css`
 
@@ -10,11 +10,11 @@ describe('Support @import', () => {
 			'@import': `"${importURL}"`,
 		})()
 
-		expect(getCssString()).toBe(`@import "${importURL}";`)
+		expect(getCssText()).toBe(`@import "${importURL}";`)
 	})
 
 	test('Authors can define multiple @import rules', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		const importURL1 = `https://unpkg.com/sanitize.css@12.0.1/sanitize.css`
 		const importURL2 = `https://unpkg.com/sanitize.css@12.0.1/typography.css`
@@ -23,11 +23,11 @@ describe('Support @import', () => {
 			'@import': [`"${importURL1}"`, `"${importURL2}"`],
 		})()
 
-		expect(getCssString()).toBe(`@import "${importURL1}";@import "${importURL2}";`)
+		expect(getCssText()).toBe(`@import "${importURL1}";@import "${importURL2}";`)
 	})
 
 	test('Authors can an @import rule without quotes', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		const importURL = `https://unpkg.com/sanitize.css@12.0.1/sanitize.css`
 
@@ -35,13 +35,13 @@ describe('Support @import', () => {
 			'@import': importURL,
 		})()
 
-		expect(getCssString()).toBe(`@import "${importURL}";`)
+		expect(getCssText()).toBe(`@import "${importURL}";`)
 	})
 }) // prettier-ignore
 
 describe('Support @font-face', () => {
 	test('Authors can define a @font-face rule', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		globalCss({
 			'@font-face': {
@@ -62,7 +62,7 @@ describe('Support @font-face', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:1 PCbjJ}` +
 			`@media{` +
 				`@font-face{` +
@@ -76,7 +76,7 @@ describe('Support @font-face', () => {
 	})
 
 	test('Authors can define multiple @font-face rules', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		globalCss({
 			'@font-face': [
@@ -115,7 +115,7 @@ describe('Support @font-face', () => {
 			],
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:1 JJHhj}` +
 			`@media{` +
 				`@font-face{` +

--- a/packages/core/tests/issue-450.js
+++ b/packages/core/tests/issue-450.js
@@ -3,7 +3,7 @@ import { createStitches } from '../src/index.js'
 describe('Issue #450', () => {
 	test('Basic Tests', () => {
 		const getFreshComponents = () => {
-			const { css, getCssString } = createStitches()
+			const { css, getCssText } = createStitches()
 
 			const component1 = css({
 				variants: {
@@ -49,50 +49,50 @@ describe('Issue #450', () => {
 				},
 			})
 
-			return { component1, component2, component3, getCssString }
+			return { component1, component2, component3, getCssText }
 		}
 
 		test('Render component1() as red, inherited from defaultVariants', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1()
 			expect(render.className).toBe(`c-PJLV c-PJLV-gmqXFB-color-red`)
-			expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red}@media{.c-PJLV-gmqXFB-color-red{color:red}}`)
+			expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red}@media{.c-PJLV-gmqXFB-color-red{color:red}}`)
 		})
 
 		test('Render component1({ color: "blue" }) as blue, assigned from props', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ color: 'blue' })
 			expect(render.className).toBe(`c-PJLV c-PJLV-kydkiA-color-blue`)
-			expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-kydkiA-color-blue}@media{.c-PJLV-kydkiA-color-blue{color:blue}}`)
+			expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-kydkiA-color-blue}@media{.c-PJLV-kydkiA-color-blue{color:blue}}`)
 		})
 
 		test('Render component1({ color: "red" }) as red, assigned from props', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ color: 'red' })
 			expect(render.className).toBe(`c-PJLV c-PJLV-gmqXFB-color-red`)
-			expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red}@media{.c-PJLV-gmqXFB-color-red{color:red}}`)
+			expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red}@media{.c-PJLV-gmqXFB-color-red{color:red}}`)
 		})
 
 		test('Render component1({ color: { "@media (width >= 640px)": "blue" } }) as red then blue, inherited from defaultVariants, assigned from props', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ color: { '@media (min-width: 640px)': 'blue' } })
 			expect(render.className).toBe(`c-PJLV c-PJLV-gmqXFB-color-red c-PJLV-bBevdw-color-blue`)
-			expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red c-PJLV-bBevdw-color-blue}@media{.c-PJLV-gmqXFB-color-red{color:red}@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}}`)
+			expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-gmqXFB-color-red c-PJLV-bBevdw-color-blue}@media{.c-PJLV-gmqXFB-color-red{color:red}@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}}`)
 		})
 
 		test('Render component2() as orange, inherited from defaultVariants', () => {
-			const { component2, getCssString } = getFreshComponents()
+			const { component2, getCssText } = getFreshComponents()
 			const render = component2()
 
 			expect(render.className).toBe(`c-PJLV c-PJLV-vMTTG-color-orange`)
-			expect(getCssString()).toBe(`--stitches{--:3 c-PJLV-vMTTG-color-orange}@media{.c-PJLV-vMTTG-color-orange{color:orange}}`)
+			expect(getCssText()).toBe(`--stitches{--:3 c-PJLV-vMTTG-color-orange}@media{.c-PJLV-vMTTG-color-orange{color:orange}}`)
 		})
 
 		test('Render component2({ color: { "@media (width >= 640px)": "blue" } }) as orange then blue, inherited from defaultVariants, assigned from props', () => {
-			const { component2, getCssString } = getFreshComponents()
+			const { component2, getCssText } = getFreshComponents()
 			const render = component2({ color: { '@media (min-width: 640px)': 'blue' } })
 			expect(render.className).toBe(`c-PJLV c-PJLV-bBevdw-color-blue c-PJLV-vMTTG-color-orange`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:3 c-PJLV-bBevdw-color-blue c-PJLV-vMTTG-color-orange}@media{` +
 					`@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}` +
 					`.c-PJLV-vMTTG-color-orange{color:orange}` +
@@ -103,7 +103,7 @@ describe('Issue #450', () => {
 
 	test('Basic Tests ported from the React version', () => {
 		const getFreshComponents = () => {
-			const { css, getCssString } = createStitches()
+			const { css, getCssText } = createStitches()
 
 			const component1 = css({
 				'--component': 1,
@@ -145,21 +145,21 @@ describe('Issue #450', () => {
 				},
 			})
 
-			return { component1, component2, getCssString }
+			return { component1, component2, getCssText }
 		}
 
 		test('Render component1()', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1()
 			expect(render.className).toBe(`c-jyxqjt`)
-			expect(getCssString()).toBe(`--stitches{--:2 c-jyxqjt}@media{.c-jyxqjt{--component:1}}`)
+			expect(getCssText()).toBe(`--stitches{--:2 c-jyxqjt}@media{.c-jyxqjt{--component:1}}`)
 		})
 
 		test('Render component1({ color: "lightBlue" })', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ color: 'lightBlue' })
 			expect(render.className).toBe(`c-jyxqjt c-jyxqjt-ilDyRi-color-lightBlue`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:2 c-jyxqjt}@media{` +
 					`.c-jyxqjt{--component:1}` +
 				`}` +
@@ -170,10 +170,10 @@ describe('Issue #450', () => {
 		})
 
 		test('Render component1({ appearance: "secondary" })', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ appearance: 'secondary' })
 			expect(render.className).toBe(`c-jyxqjt c-jyxqjt-cOChOn-appearance-secondary`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:2 c-jyxqjt}@media{` +
 					`.c-jyxqjt{--component:1}` +
 				`}` +
@@ -184,10 +184,10 @@ describe('Issue #450', () => {
 		})
 
 		test('Render component1({ appearance: "secondary", color: "lightBlue" })', () => {
-			const { component1, getCssString } = getFreshComponents()
+			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ appearance: 'secondary', color: 'lightBlue' })
 			expect(render.className).toBe(`c-jyxqjt c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:2 c-jyxqjt}@media{` +
 					`.c-jyxqjt{--component:1}` +
 				`}` +
@@ -202,10 +202,10 @@ describe('Issue #450', () => {
 		})
 
 		test('Render component2()', () => {
-			const { component2, getCssString } = getFreshComponents()
+			const { component2, getCssText } = getFreshComponents()
 			const render = component2()
 			expect(render.className).toBe(`c-jyxqjt c-dkRcuu c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +
 					`.c-dkRcuu{--component:2}` +
@@ -221,10 +221,10 @@ describe('Issue #450', () => {
 		})
 
 		test('Render component2({ appearance: "secondary", color: "lightBlue" })', () => {
-			const { component2, getCssString } = getFreshComponents()
+			const { component2, getCssText } = getFreshComponents()
 			const render = component2({ appearance: 'secondary', color: 'lightBlue' })
 			expect(render.className).toBe(`c-jyxqjt c-dkRcuu c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue c-jyxqjt-gYqlvA-cv`)
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +
 					`.c-dkRcuu{--component:2}` +

--- a/packages/core/tests/issue-492.js
+++ b/packages/core/tests/issue-492.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Issue #492', () => {
 	test('Conditionally apply default variants as the @initial value', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component = css({
 			variants: {
@@ -37,7 +37,7 @@ describe('Issue #492', () => {
 		)
 
 		expect(
-			getCssString()
+			getCssText()
 		).toBe(
 			`--stitches{--:3 ${variantSweetCarolineClassName}}@media{` +
 				`.${variantSweetCarolineClassName}{--sweet-caroline:true}` +
@@ -58,7 +58,7 @@ describe('Issue #492', () => {
 		)
 
 		expect(
-			getCssString()
+			getCssText()
 		).toBe(
 			`--stitches{--:3 ${variantSweetCarolineClassName} ${variantResponsiveSweetDreamsClassName}}@media{` +
 				`.${variantSweetCarolineClassName}{--sweet-caroline:true}` +
@@ -81,7 +81,7 @@ describe('Issue #492', () => {
 		)
 
 		expect(
-			getCssString()
+			getCssText()
 		).toBe(
 			`--stitches{--:3 ${variantSweetCarolineClassName} ${variantResponsiveSweetDreamsClassName} ${variantSweetDreamsClassName} ${variantResponsiveSweetCarolineClassName}}@media{` +
 				// last rendering
@@ -95,7 +95,7 @@ describe('Issue #492', () => {
 	})
 
 	test('Apply apply @initial styles first', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		const component = css({
 			'--rock': true,
@@ -130,7 +130,7 @@ describe('Issue #492', () => {
 		)
 
 		expect(
-			getCssString()
+			getCssText()
 		).toBe(
 			`--stitches{--:2 ${componentClassName}}@media{` +
 				`.${componentClassName}{--rock:true}` +

--- a/packages/core/tests/issue-999.js
+++ b/packages/core/tests/issue-999.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Issue #519', () => {
 	test('locally scoped token works 1 time', () => {
-		const { css, getCssString } = createStitches({ prefix: 'fusion' })
+		const { css, getCssText } = createStitches({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -12,7 +12,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 fusion-c-fjkySu}` +
 			`@media{` +
 				`.fusion-c-fjkySu{--fusion--syntax:red}` +
@@ -22,7 +22,7 @@ describe('Issue #519', () => {
 	})
 
 	test('locally scoped prefix-free token works 1 time', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			$$syntax: 'red',
@@ -32,7 +32,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-fjkySu}` +
 			`@media{` +
 				`.c-fjkySu{---syntax:red}` +
@@ -42,7 +42,7 @@ describe('Issue #519', () => {
 	})
 
 	test('locally scoped token works 2 times', () => {
-		const { css, getCssString } = createStitches({ prefix: 'fusion' })
+		const { css, getCssText } = createStitches({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -56,7 +56,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 fusion-c-lkpaIy}` +
 			`@media{` +
 				`.fusion-c-lkpaIy{--fusion--syntax:red}` +
@@ -67,7 +67,7 @@ describe('Issue #519', () => {
 	})
 
 	test('locally scoped prefix-free token works 2 times', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			$$syntax: 'red',
@@ -81,7 +81,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-lkpaIy}` +
 			`@media{` +
 				`.c-lkpaIy{---syntax:red}` +
@@ -92,7 +92,7 @@ describe('Issue #519', () => {
 	})
 
 	test('locally scoped token works 3 times', () => {
-		const { css, getCssString } = createStitches({ prefix: 'fusion' })
+		const { css, getCssText } = createStitches({ prefix: 'fusion' })
 
 		css({
 			$$syntax: 'red',
@@ -110,7 +110,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 fusion-c-kbkiiL}` +
 			`@media{` +
 				`.fusion-c-kbkiiL{--fusion--syntax:red}` +
@@ -122,7 +122,7 @@ describe('Issue #519', () => {
 	})
 
 	test('locally scoped prefix-free token works 3 times', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			$$syntax: 'red',
@@ -140,7 +140,7 @@ describe('Issue #519', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-kbkiiL}` +
 			`@media{` +
 				`.c-kbkiiL{---syntax:red}` +

--- a/packages/core/tests/theme.js
+++ b/packages/core/tests/theme.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Theme', () => {
 	test('Expected behavior for the createTheme() method', () => {
-		const { createTheme, getCssString } = createStitches()
+		const { createTheme, getCssText } = createStitches()
 
 		const myTheme = createTheme('my', {
 			colors: {
@@ -10,16 +10,16 @@ describe('Theme', () => {
 			},
 		})
 
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 		expect(`<div class="${myTheme}">`).toBe('<div class="my">')
-		expect(getCssString()).toBe(`--stitches{--:0 my}@media{.my{--colors-blue:dodgerblue}}`)
+		expect(getCssText()).toBe(`--stitches{--:0 my}@media{.my{--colors-blue:dodgerblue}}`)
 		expect(myTheme.className).toBe('my')
 		expect(myTheme.selector).toBe('.my')
 	})
 
 	test('createTheme() support for non-strings', () => {
 		{
-			const { getCssString } = createStitches({
+			const { getCssText } = createStitches({
 				theme: {
 					sizes: {
 						sm: 100,
@@ -29,7 +29,7 @@ describe('Theme', () => {
 				}
 			})
 
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:0 t-egkarf}@media{` +
 					`:root,.t-egkarf{--sizes-sm:100;--sizes-md:200;--sizes-lg:500}` +
 				`}`
@@ -37,7 +37,7 @@ describe('Theme', () => {
 		}
 
 		{
-			const { getCssString } = createStitches({
+			const { getCssText } = createStitches({
 				theme: {
 					sizes: {
 						sm: 100,
@@ -47,7 +47,7 @@ describe('Theme', () => {
 				}
 			})
 
-			expect(getCssString()).toBe(
+			expect(getCssText()).toBe(
 				`--stitches{--:0 t-eJkcVD}@media{` +
 					`:root,.t-eJkcVD{` +
 						`--sizes-sm:100;` +

--- a/packages/core/tests/universal-nesting.js
+++ b/packages/core/tests/universal-nesting.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Nesting', () => {
 	test('Authors can define globalCss nesting rules', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		globalCss({
 			'body > a': {
@@ -12,11 +12,11 @@ describe('Nesting', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(`--stitches{--:1 hXsVBR}@media{body > a:not(:hover){text-decoration:none}}`)
+		expect(getCssText()).toBe(`--stitches{--:1 hXsVBR}@media{body > a:not(:hover){text-decoration:none}}`)
 	})
 
 	test('Authors can define component nesting rules', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			'&:not(:hover)': {
@@ -24,11 +24,11 @@ describe('Nesting', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(`--stitches{--:2 c-dweUti}@media{.c-dweUti:not(:hover){text-decoration:none}}`)
+		expect(getCssText()).toBe(`--stitches{--:2 c-dweUti}@media{.c-dweUti:not(:hover){text-decoration:none}}`)
 	})
 
 	test('Authors can define recursive globalCss nesting rules', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		globalCss({
 			p: {
@@ -39,11 +39,11 @@ describe('Nesting', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(`--stitches{--:1 gkqgGk}@media{p{margin:0}p ~ p{margin-top:0}}`)
+		expect(getCssText()).toBe(`--stitches{--:1 gkqgGk}@media{p{margin:0}p ~ p{margin-top:0}}`)
 	})
 
 	test('Authors can define recursive component nesting rules', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			'margin': 0,
@@ -52,11 +52,11 @@ describe('Nesting', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(`--stitches{--:2 c-fuGzNQ}@media{.c-fuGzNQ{margin:0}.c-fuGzNQ ~ .c-fuGzNQ{margin-top:0}}`)
+		expect(getCssText()).toBe(`--stitches{--:2 c-fuGzNQ}@media{.c-fuGzNQ{margin:0}.c-fuGzNQ ~ .c-fuGzNQ{margin-top:0}}`)
 	})
 
 	test('Authors can define complex recursive globalCss nesting rules', () => {
-		const { globalCss, getCssString } = createStitches()
+		const { globalCss, getCssText } = createStitches()
 
 		globalCss({
 			'body > p, body > ul': {
@@ -70,11 +70,11 @@ describe('Nesting', () => {
 		const parentCssRule = `body > p,body > ul{margin:0}`
 		const nestingCssRule = `:is(body > p) ~ :is(body > p),:is(body > ul) ~ :is(body > ul){margin-top:0}`
 
-		expect(getCssString()).toBe(`--stitches{--:1 cugdJ}@media{${parentCssRule + nestingCssRule}}`)
+		expect(getCssText()).toBe(`--stitches{--:1 cugdJ}@media{${parentCssRule + nestingCssRule}}`)
 	})
 
 	test('Authors can define complex recursive component nesting rules', () => {
-		const { css, getCssString } = createStitches()
+		const { css, getCssText } = createStitches()
 
 		css({
 			'& > p, & > ul': {
@@ -88,6 +88,6 @@ describe('Nesting', () => {
 		const parentCssRule = `.c-iJLHRt > p,.c-iJLHRt > ul{margin:0}`
 		const nestingCssRule = `:is(.c-iJLHRt > p) ~ :is(.c-iJLHRt > p),:is(.c-iJLHRt > ul) ~ :is(.c-iJLHRt > ul){margin-top:0}`
 
-		expect(getCssString()).toBe(`--stitches{--:2 c-iJLHRt}@media{${parentCssRule + nestingCssRule}}`)
+		expect(getCssText()).toBe(`--stitches{--:2 c-iJLHRt}@media{${parentCssRule + nestingCssRule}}`)
 	})
 })

--- a/packages/core/tests/universal-numeric-values.js
+++ b/packages/core/tests/universal-numeric-values.js
@@ -49,7 +49,7 @@ describe('Numeric Values', () => {
 
 	test('Authors can use unit-less properties as known to React', () => {
 		for (let i = 0; i <= 33; i += 11) {
-			const { globalCss, getCssString } = createStitches()
+			const { globalCss, getCssText } = createStitches()
 
 			globalCss({
 				div: {
@@ -87,7 +87,7 @@ describe('Numeric Values', () => {
 				},
 			})()
 
-			const cssText = getCssString().replace(/^.+@media\{|\}$/g, '')
+			const cssText = getCssText().replace(/^.+@media\{|\}$/g, '')
 
 			expect(cssText).toBe(
 				'div' + '{' +
@@ -135,7 +135,7 @@ describe('Numeric Values', () => {
 
 		test(`Author can use the unit-only ${kebabProp} property`, () => {
 			for (let i = 0; i <= 33; i += 11) {
-				const { globalCss, getCssString } = createStitches()
+				const { globalCss, getCssText } = createStitches()
 
 				globalCss({
 					div: {
@@ -143,7 +143,7 @@ describe('Numeric Values', () => {
 					},
 				})()
 
-				const cssText = getCssString().replace(/^.+@media\{|\}$/g, '')
+				const cssText = getCssText().replace(/^.+@media\{|\}$/g, '')
 
 				expect(cssText).toBe(
 					`div{` +

--- a/packages/core/tests/universal-serialization.js
+++ b/packages/core/tests/universal-serialization.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Serialization', () => {
 	const sheet = createStitches()
-	const { css, getCssString, toString, createTheme } = sheet
+	const { css, getCssText, toString, createTheme } = sheet
 
 	const myComponent = css({
 		all: 'unset',
@@ -55,7 +55,7 @@ describe('Serialization', () => {
 	})
 
 	test('Sheets can explicitly return their cssText', () => {
-		expect(getCssString()).toBe(sheetCssText)
+		expect(getCssText()).toBe(sheetCssText)
 		expect(toString()).toBe(sheetCssText)
 	})
 })

--- a/packages/core/tests/universal-tokens.js
+++ b/packages/core/tests/universal-tokens.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Tokens', () => {
 	test('Authors can use a regular token #1', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				colors: {
 					red: 'tomato',
@@ -16,7 +16,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-iknykm}@media{` +
 				`:root,.t-iknykm{--colors-red:tomato}` +
 			`}--stitches{--:1 fMIGFF}@media{` +
@@ -26,7 +26,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use a regular token #2', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				shadows: {
 					red: 'tomato',
@@ -40,7 +40,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-daOLKV}@media{` +
 				`:root,.t-daOLKV{--shadows-red:tomato}` +
 			`}--stitches{--:1 bstpNq}@media{` +
@@ -50,7 +50,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use a relative token #1', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				colors: {
 					red: 'tomato',
@@ -65,7 +65,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-eZaaph}@media{` +
 				`:root,.t-eZaaph{--colors-red:tomato;--colors-red500:var(--colors-red)}` +
 			`}--stitches{--:1 fdgxsg}@media{` +
@@ -75,7 +75,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use a relative token #1', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				shadows: {
 					red: 'tomato',
@@ -91,7 +91,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-gxqihb}@media{` +
 				`:root,.t-gxqihb{--shadows-red:tomato;--shadows-red500:var(--shadows-red);--shadows-redUnique:var(---red)}` +
 			`}` +
@@ -102,7 +102,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use an absolute token #1', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				colors: {
 					red: 'tomato',
@@ -116,7 +116,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-iknykm}@media{` +
 				`:root,.t-iknykm{--colors-red:tomato}` +
 			`}` +
@@ -127,7 +127,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use an absolute token #2', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				colors: {
 					red: 'tomato',
@@ -141,7 +141,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-iknykm}@media{` +
 				`:root,.t-iknykm{--colors-red:tomato}` +
 			`}` +
@@ -152,7 +152,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use a negative token #1', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				space: {
 					sp1: '100px',
@@ -168,7 +168,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-hxjLZl}@media{` +
 				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
 			`}` +
@@ -179,7 +179,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use a negative token #2', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				sizes: {
 					sp1: '10px',
@@ -196,7 +196,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-ereMzu}@media{` +
 				`:root,.t-ereMzu{--sizes-sp1:10px;--sizes-sp2:20px;--sizes-sp3:30px}` +
 			`}` +
@@ -207,7 +207,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use tokens from the globalCss theme object', () => {
-		const { globalCss, theme, getCssString } = createStitches({
+		const { globalCss, theme, getCssText } = createStitches({
 			theme: {
 				space: {
 					sp1: '100px',
@@ -223,7 +223,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-hxjLZl}@media{` +
 				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
 			`}` +
@@ -234,7 +234,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use tokens from a new theme object', () => {
-		const { globalCss, createTheme, getCssString } = createStitches()
+		const { globalCss, createTheme, getCssText } = createStitches()
 
 		const mytheme = createTheme('my-theme', {
 			space: {
@@ -250,13 +250,13 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:1 lcIUgV}@media{article{margin-left:var(--space-sp1);margin-top:var(--space-sp2)}}`,
 		)
 
 		void `${mytheme}`
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 my-theme}@media{` +
 				`.my-theme{--space-sp1:100px;--space-sp2:200px}` +
 			`}--stitches{--:1 lcIUgV}@media{` +
@@ -266,7 +266,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use tokens from the globalCss theme object', () => {
-		const { globalCss, theme, getCssString } = createStitches({
+		const { globalCss, theme, getCssText } = createStitches({
 			theme: {
 				space: {
 					sp1: '100px',
@@ -282,7 +282,7 @@ describe('Tokens', () => {
 			},
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-hxjLZl}@media{` +
 				`:root,.t-hxjLZl{--space-sp1:100px;--space-sp2:200px}` +
 			`}` +
@@ -293,7 +293,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can use the class from the root theme object', () => {
-		const { theme, getCssString } = createStitches({
+		const { theme, getCssText } = createStitches({
 			prefix: 'pedro',
 			theme: {
 				colors: {
@@ -304,7 +304,7 @@ describe('Tokens', () => {
 
 		expect(`<div class="${theme}"></div>`).toBe(`<div class="pedro-t-jPkpUS"></div>`)
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 pedro-t-jPkpUS}@media{` +
 				`:root,.pedro-t-jPkpUS{--pedro-colors-blue:dodgerblue}` +
 			`}`
@@ -312,7 +312,7 @@ describe('Tokens', () => {
 	})
 
 	test('Authors can render custom units', () => {
-		const { globalCss, getCssString } = createStitches({
+		const { globalCss, getCssText } = createStitches({
 			theme: {
 				sizes: {
 					five: '5px',
@@ -326,7 +326,7 @@ describe('Tokens', () => {
 			}
 		})()
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:0 t-bhZLEQ}@media{` +
 				`:root,.t-bhZLEQ{--sizes-five:5px}` +
 			`}--stitches{--:1 gvABwA}@media{` +

--- a/packages/core/types/sheet.d.ts
+++ b/packages/core/types/sheet.d.ts
@@ -92,7 +92,7 @@ export default interface Sheet<
 	reset: {
 		(): void
 	}
-	getCssString: {
+	getCssText: {
 		(): string
 	},
 	css: {

--- a/packages/react/tests/basic.js
+++ b/packages/react/tests/basic.js
@@ -4,7 +4,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Basic', () => {
 	test('Functionality of styled()', () => {
-		const { styled, getCssString } = createStitches({
+		const { styled, getCssText } = createStitches({
 			utils: {
 				userSelect: () => (value) => ({
 					WebkitUserSelector: value,
@@ -41,7 +41,7 @@ describe('Basic', () => {
 			children: ['Hello, World!'],
 		})
 
-		expect(getCssString()).toBe(
+		expect(getCssText()).toBe(
 			`--stitches{--:2 c-iSEgvG}@media{.c-iSEgvG{background-color:gainsboro;border-radius:9999px;font-weight:500;padding:0.75em 1em;border:0;transition:all 200ms ease}.c-iSEgvG:hover{transform:translateY(-2px);box-shadow:0 10px 25px rgba(0, 0, 0, .3)}}`,
 		)
 	})

--- a/packages/react/tests/component-composition.js
+++ b/packages/react/tests/component-composition.js
@@ -2,29 +2,29 @@ import { createStitches } from '../src/index.js'
 
 describe('Composition', () => {
 	test('Renders an empty component', () => {
-		const { styled, getCssString } = createStitches()
+		const { styled, getCssText } = createStitches()
 		const generic = styled()
 		expect(generic.render().props).toEqual({ className: 'PJLV' })
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Does not render a component without an explicit rendering', () => {
-		const { styled, getCssString } = createStitches()
+		const { styled, getCssText } = createStitches()
 		const red = styled({ color: 'red' })
 		const size14 = styled({ fontSize: '14px' })
 		const bold = styled({ fontWeight: 'bold' })
 		const title = styled(red, size14, bold, { fontFamily: 'monospace' })
 		expect(`${title}`).toBe('.c-gmqXFB')
-		expect(getCssString()).toBe('')
+		expect(getCssText()).toBe('')
 	})
 
 	test('Renders a component with all compositions', () => {
-		const { styled, getCssString } = createStitches()
+		const { styled, getCssText } = createStitches()
 		const red = styled({ color: 'red' })
 		const size14 = styled({ fontSize: '14px' })
 		const bold = styled({ fontWeight: 'bold' })
 		const title = styled(red, size14, bold, { fontFamily: 'monospace' })
 		expect(title.render().props.className).toBe('c-gmqXFB c-hzkWus c-cQFdVt c-kngyIZ')
-		expect(getCssString()).toBe('--stitches{--:2 c-gmqXFB c-hzkWus c-cQFdVt c-kngyIZ}@media{.c-gmqXFB{color:red}.c-hzkWus{font-size:14px}.c-cQFdVt{font-weight:bold}.c-kngyIZ{font-family:monospace}}')
+		expect(getCssText()).toBe('--stitches{--:2 c-gmqXFB c-hzkWus c-cQFdVt c-kngyIZ}@media{.c-gmqXFB{color:red}.c-hzkWus{font-size:14px}.c-cQFdVt{font-weight:bold}.c-kngyIZ{font-family:monospace}}')
 	})
 })

--- a/packages/react/tests/issue-416.js
+++ b/packages/react/tests/issue-416.js
@@ -4,7 +4,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Issue #416: Composition versus Descendancy', () => {
 	{
-		const { styled, getCssString } = createStitches()
+		const { styled, getCssText } = createStitches()
 
 		const BoxA = styled('main', {
 			variants: {
@@ -76,7 +76,7 @@ describe('Issue #416: Composition versus Descendancy', () => {
 			() => expect(boxZ.props.className).toBe(`${baselineClass} ${variantZClass}`)
 		)
 
-		test('All variant CSS is generated', () => expect(getCssString()).toBe(
+		test('All variant CSS is generated', () => expect(getCssText()).toBe(
 			`--stitches{--:3 c-PJLV-kgptgY-foo-bar c-PJLV-cHNUhn-foo-bar c-PJLV-vFFMz-foo-bar}@media{` +
 				`.c-PJLV-kgptgY-foo-bar{--box-a:foo-bar}` +
 				`.c-PJLV-cHNUhn-foo-bar{--box-b:foo-bar}` +

--- a/packages/react/tests/issue-450.js
+++ b/packages/react/tests/issue-450.js
@@ -14,7 +14,7 @@ let RenderOf = (...typeThenPropsThenChildren) => {
 
 describe('Issue #450', () => {
 	test('Compound variants apply to composed components (basic)', () => {
-		const { styled, getCssString } = createStitches()
+		const { styled, getCssText } = createStitches()
 
 		const Happy = styled('div', {
 			'--is-happy': true,
@@ -45,7 +45,7 @@ describe('Issue #450', () => {
 		)
 
 		expect(
-			getCssString()
+			getCssText()
 		).toBe(
 			// composition styles
 			`--stitches{--:2 c-fEpFmO}@media{` +

--- a/packages/react/tests/universal-serialization.js
+++ b/packages/react/tests/universal-serialization.js
@@ -2,7 +2,7 @@ import { createStitches } from '../src/index.js'
 
 describe('Serialization', () => {
 	const sheet = createStitches()
-	const { styled, getCssString, toString, createTheme } = sheet
+	const { styled, getCssText, toString, createTheme } = sheet
 
 	const myComponent = styled('button', {
 		all: 'unset',
@@ -57,7 +57,7 @@ describe('Serialization', () => {
 	})
 
 	test('Sheets can explicitly return their cssText', () => {
-		expect(getCssString()).toBe(sheetCssText)
+		expect(getCssText()).toBe(sheetCssText)
 		expect(toString()).toBe(sheetCssText)
 	})
 })

--- a/packages/react/types/sheet.d.ts
+++ b/packages/react/types/sheet.d.ts
@@ -92,7 +92,7 @@ export default interface Sheet<
 	reset: {
 		(): void
 	}
-	getCssString: {
+	getCssText: {
 		(): string
 	},
 	css: {


### PR DESCRIPTION
This renames the `getCssString` function to `getCssText`.

```tsx
import { createStitches } from '@stitches/core'

const { getCssString } = createStitches()
```

```tsx
import { createStitches } from '@stitches/react'

const { getCssString } = createStitches()
```