### PR TITLE
fix: sizing polyfill

### DIFF
--- a/packages/core/src/convert/toSizingValue.js
+++ b/packages/core/src/convert/toSizingValue.js
@@ -1,3 +1,5 @@
+import { toHyphenCase } from './toHyphenCase.js'
+
 /** Returns a declaration sizing value with polyfilled sizing keywords. */
 export const toSizingValue = (/** @type {string} */ declarationName, /** @type {string} */ declarationValue) => (
 	declarationName in sizeProps && typeof declarationValue === 'string'
@@ -6,8 +8,8 @@ export const toSizingValue = (/** @type {string} */ declarationName, /** @type {
 			(data, lead, main, tail) => (
 				lead + (
 					main === 'stretch'
-						? `-moz-available${tail};${declarationName}:${lead}-webkit-fill-available`
-					: `-moz-fit-content${tail};${declarationName}:${lead}fit-content`
+						? `-moz-available${tail};${toHyphenCase(declarationName)}:${lead}-webkit-fill-available`
+					: `-moz-fit-content${tail};${toHyphenCase(declarationName)}:${lead}fit-content`
 				) + tail
 			),
 		)

--- a/packages/core/tests/issue-655.js
+++ b/packages/core/tests/issue-655.js
@@ -1,0 +1,20 @@
+import { createStitches } from '../src/index.js'
+
+describe('Issue #655', () => {
+	test('Applying both variants from the one default variant', () => {
+		const { css, getCssText } = createStitches()
+
+		css({
+			maxWidth: 'fit-content',
+			minWidth: 'fit-content',
+		})()
+
+		expect(getCssText()).toBe(
+			`--stitches{--:2 c-dAAqmb}` +
+			`@media{.c-dAAqmb{` +
+				`max-width:-moz-fit-content;max-width:fit-content;` +
+				`min-width:-moz-fit-content;min-width:fit-content` +
+			`}}`
+		)
+	})
+})


### PR DESCRIPTION
This fixes the sizing value polyfilling within Stitches, addressing #655.

```tsx
const { css, getCssText } = createStitches()

css({
	maxWidth: 'fit-content',
	minWidth: 'fit-content',
})()

getCssText()
/*
	max-width: -moz-fit-content; max-width: fit-content;
	min-width: -moz-fit-content; min-width: fit-content;
*/
```