### PR TITLE
fix: return type for createTheme

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -77,11 +77,9 @@ export default interface Stitches<
 				selector: string
 			}
 			& (
-				Argument0 extends {}
-					? ThemeTokens<Argument0, Prefix>
-				: Argument1 extends {}
+				Argument0 extends string
 					? ThemeTokens<Argument1, Prefix>
-				: {}
+					: ThemeTokens<Argument0, Prefix>
 			)
 	}
 	theme: string & {


### PR DESCRIPTION
fixes: modulz/stitches#713

Check if arg0 is a string (theme class name), if so, include tokens from arg1, otherwise, include tokens from arg0