### PR TITLE
Fix: Allow string type on `z-index`

### DIFF
--- a/.task/build-csstype.js
+++ b/.task/build-csstype.js
@@ -24,6 +24,7 @@ const generateType = async (packageUrl) => {
 		.withFixedNestingSelectors
 		.withFixedStretchValue
 		.withFixedSystemColor
+		.withFixedZIndex
 
 		.withoutBrowserComments
 		.withoutImplicitGlobals
@@ -143,6 +144,13 @@ class ModifiedString extends String {
 		).replace(
 			/DeprecatedSystemColor/g,
 			'SystemColor'
+		)
+	}
+
+	get withFixedZIndex() {
+		return this.replace(
+			'type ZIndex = Globals | "auto" | (number & {})',
+			'type ZIndex = Globals | "auto" | number | (string & {})'
 		)
 	}
 

--- a/packages/core/types/css.d.ts
+++ b/packages/core/types/css.d.ts
@@ -8824,7 +8824,7 @@ export namespace Property {
 
   export type WritingMode = "horizontal-tb" | "sideways-lr" | "sideways-rl" | "vertical-lr" | "vertical-rl";
 
-  export type ZIndex = "auto" | OnlyNumber;
+  export type ZIndex = "auto" | OnlyStringNumeric;
 
   export type Zoom = "normal" | "reset" | OnlyStringNumeric;
 

--- a/packages/react/types/css.d.ts
+++ b/packages/react/types/css.d.ts
@@ -8824,7 +8824,7 @@ export namespace Property {
 
   export type WritingMode = "horizontal-tb" | "sideways-lr" | "sideways-rl" | "vertical-lr" | "vertical-rl";
 
-  export type ZIndex = "auto" | OnlyNumber;
+  export type ZIndex = "auto" | OnlyStringNumeric;
 
   export type Zoom = "normal" | "reset" | OnlyStringNumeric;
 


### PR DESCRIPTION
This patches the `csstype` package to accept strings on the `zIndex` property.

Resolves #726