### PR TITLE
fix(defaultThemeMap): add borderImage to default to support colors

### DIFF
--- a/packages/core/src/default/defaultThemeMap.js
+++ b/packages/core/src/default/defaultThemeMap.js
@@ -86,7 +86,7 @@ export const defaultThemeMap = {
 	background: colors,
 	backgroundColor: colors,
 	backgroundImage: colors,
-	boderImage: colors,
+	borderImage: colors,
 	border: colors,
 	borderBlock: colors,
 	borderBlockEnd: colors,

--- a/packages/core/src/default/defaultThemeMap.js
+++ b/packages/core/src/default/defaultThemeMap.js
@@ -86,6 +86,7 @@ export const defaultThemeMap = {
 	background: colors,
 	backgroundColor: colors,
 	backgroundImage: colors,
+	boderImage: colors,
 	border: colors,
 	borderBlock: colors,
 	borderBlockEnd: colors,

--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -115,7 +115,7 @@ export interface DefaultThemeMap {
 	background: 'colors'
 	backgroundColor: 'colors'
 	backgroundImage: 'colors'
-	boderImage: 'colors'
+	borderImage: 'colors'
 	border: 'colors'
 	borderBlock: 'colors'
 	borderBlockEnd: 'colors'

--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -115,6 +115,7 @@ export interface DefaultThemeMap {
 	background: 'colors'
 	backgroundColor: 'colors'
 	backgroundImage: 'colors'
+	boderImage: 'colors'
 	border: 'colors'
 	borderBlock: 'colors'
 	borderBlockEnd: 'colors'

--- a/packages/core/types/css.d.ts
+++ b/packages/core/types/css.d.ts
@@ -215,14 +215,14 @@ export interface StandardLonghandProperties {
    */
   backgroundImage?: Property.BackgroundImage;
 	/**
-   * The **`boder-image`** CSS property sets one or more boder images on an element.
+   * The **`border-image`** CSS property draws an image around a given element.
    *
    * **Syntax**: `<border-image>#`
    *
-   * **Initial value**: `none`
+   * **Initial value**: `none 100% / 1 / 0 stretch`
    *
    */
-	 boderImage?: Property.BackgroundImage;
+	 borderImage?: Property.BackgroundImage;
   /**
    * The **`background-origin`** CSS property sets the background's origin: from the border start, inside the border, or inside the padding.
    *

--- a/packages/core/types/css.d.ts
+++ b/packages/core/types/css.d.ts
@@ -214,6 +214,15 @@ export interface StandardLonghandProperties {
    *
    */
   backgroundImage?: Property.BackgroundImage;
+	/**
+   * The **`boder-image`** CSS property sets one or more boder images on an element.
+   *
+   * **Syntax**: `<border-image>#`
+   *
+   * **Initial value**: `none`
+   *
+   */
+	 boderImage?: Property.BackgroundImage;
   /**
    * The **`background-origin`** CSS property sets the background's origin: from the border start, inside the border, or inside the padding.
    *

--- a/packages/react/types/config.d.ts
+++ b/packages/react/types/config.d.ts
@@ -115,6 +115,7 @@ export interface DefaultThemeMap {
 	background: 'colors'
 	backgroundColor: 'colors'
 	backgroundImage: 'colors'
+	borderImage: 'colors'
 	border: 'colors'
 	borderBlock: 'colors'
 	borderBlockEnd: 'colors'

--- a/packages/react/types/css.d.ts
+++ b/packages/react/types/css.d.ts
@@ -215,14 +215,14 @@ export interface StandardLonghandProperties {
    */
   backgroundImage?: Property.BackgroundImage;
 	/**
-   * The **`boder-image`** CSS property sets one or more boder images on an element.
+   * The **`border-image`** CSS property draws an image around a given element.
    *
    * **Syntax**: `<border-image>#`
    *
-   * **Initial value**: `none`
+   * **Initial value**: `none 100% / 1 / 0 stretch`
    *
    */
-	 boderImage?: Property.BackgroundImage;
+	 borderImage?: Property.BackgroundImage;
   /**
    * The **`background-origin`** CSS property sets the background's origin: from the border start, inside the border, or inside the padding.
    *

--- a/packages/react/types/css.d.ts
+++ b/packages/react/types/css.d.ts
@@ -214,6 +214,15 @@ export interface StandardLonghandProperties {
    *
    */
   backgroundImage?: Property.BackgroundImage;
+	/**
+   * The **`boder-image`** CSS property sets one or more boder images on an element.
+   *
+   * **Syntax**: `<border-image>#`
+   *
+   * **Initial value**: `none`
+   *
+   */
+	 boderImage?: Property.BackgroundImage;
   /**
    * The **`background-origin`** CSS property sets the background's origin: from the border start, inside the border, or inside the padding.
    *


### PR DESCRIPTION
Hi there! Thanks for creating awesome stitches let me can easily build a design system by myself.

I found a little issue and tried to fix it. I added [lineGradient util](https://stitches.dev/docs/utils) into my stitches config and want to apply the gradient color to the border color, it always can't be applied, so I inline gradient color, and it works.

**✅ Works**

```ts
borderImage: 'linear-gradient(to left, #743ad5, #d53a9d)'
```

**❌ Failure**
```tsx
borderImage: 'linear-gradient($primary400)',
```

So I check the source code and guess it be missed in the `defaultThemeMap` config, hope it can be fixed, Thanks!

Signed-off-by: Jie Peng <im@jiepeng.me>