### PR TITLE
fix: return type for createTheme

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -98,11 +98,9 @@ export default interface Stitches<
 				selector: string
 			}
 			& (
-				Argument0 extends {}
-					? ThemeTokens<Argument0, Prefix>
-				: Argument1 extends {}
+				Argument0 extends string
 					? ThemeTokens<Argument1, Prefix>
-				: {}
+					: ThemeTokens<Argument0, Prefix>
 			)
 	}
 	theme: string & {

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -98,11 +98,9 @@ export default interface Stitches<
 				selector: string
 			}
 			& (
-				Argument0 extends {}
-					? ThemeTokens<Argument0, Prefix>
-				: Argument1 extends {}
+				Argument0 extends string
 					? ThemeTokens<Argument1, Prefix>
-				: {}
+					: ThemeTokens<Argument0, Prefix>
 			)
 	}
 	theme: string & {


### PR DESCRIPTION
fixes #713, which was previously fixed in #714 

Unfortunately, the fix was reverted here: https://github.com/modulz/stitches/commit/066bf69db523cd7167e7f9557447e9a00a57491e#diff-f616198a03e95b0c1089cfaaf95c6dfefc2d0e3da584cdba2c14d7656ef3f3d8

Additionally, the original fix was for core/types/stitches.d.ts but this code also exists in react/types/stitches.d.ts



