### PR TITLE
Fix: Allow string array type for global at import rule

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -35,7 +35,7 @@ export default interface Stitches<
 				'@font-face'?: unknown
 			} & {
 				[K in Prelude]: K extends '@import'
-					? string
+					? string | string[]
 				: K extends '@font-face'
 					? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
 				: K extends `@keyframes ${string}`


### PR DESCRIPTION
Since `v.1.0.0` the allowed type of `string[]` for `@import` rules was removed from `globalCss`.
The actual functionality remained unchanged, because multiple `@import` rules still work. 

This PR re-adds support for `string[]` types inside `globalCss`.