### PR TITLE
fix: VariantProps symbol type error

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -39,7 +39,7 @@ export type PropertyValue<K extends keyof CSSUtil.CSSProperties> = { readonly [C
 export type ScaleValue<K> = { readonly [CSSUtil.$$ScaleValue]: K }
 
 /** Returns a type that suggests variants from a component as possible prop values. */
-export type VariantProps<Component extends {[key: symbol]: any}> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
+export type VariantProps<Component extends {[key: symbol | string]: any}> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
 
 /** Map of CSS properties to token scales. */
 export declare const defaultThemeMap: DefaultThemeMap

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -39,7 +39,7 @@ export type PropertyValue<K extends keyof CSSUtil.CSSProperties> = { readonly [C
 export type ScaleValue<K> = { readonly [CSSUtil.$$ScaleValue]: K }
 
 /** Returns a type that suggests variants from a component as possible prop values. */
-export type VariantProps<Component> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
+export type VariantProps<Component extends {[key: symbol]: any}> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
 
 /** Map of CSS properties to token scales. */
 export declare const defaultThemeMap: DefaultThemeMap


### PR DESCRIPTION
This fixes the error `Type 'unique symbol' cannot be used to index type 'Component'.` when trying to build a TypeScript app, addressing https://github.com/modulz/stitches/issues/754.