### PR TITLE
Support n composition in `globalCss` function

### DIFF
--- a/packages/core/tests/basic.js
+++ b/packages/core/tests/basic.js
@@ -66,7 +66,7 @@ describe('Basic', () => {
 
 		expect(rendering2of2).toBeInstanceOf(Function)
 		expect(className2of2).toBe('')
-		expect(cssString2of2).toBe(`--sxs{--sxs:1 PJLV cSHHDh}@media{body{margin:0}}`)
+		expect(cssString2of2).toBe(`--sxs{--sxs:1 cSHHDh}@media{body{margin:0}}`)
 	})
 
 	test('Functionality of keyframes()', () => {

--- a/packages/core/tests/types.test.ts
+++ b/packages/core/tests/types.test.ts
@@ -52,22 +52,13 @@ keyframes({
 })
 
 globalCss({
-	hello: {
+	body: {
 		'@bp1': {
 			backgroundColor: '$gray100',
 		},
 		backgroundColor: '$gray300',
 	},
 })
-
-// const externalStyles: Arg<typeof css> = {
-// 	'@bp1': {
-// 		backgroundColor: '$gray100',
-// 	},
-// 	'backgroundColor': '$gray300',
-// }
-
-// void externalStyles
 
 const PotatoButton = css({
 	variants: {

--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -28,24 +28,27 @@ export default interface Stitches<
 	 */
 	globalCss: {
 		<Prelude extends string>(
-			style: {
-				/** The **@import** CSS at-rule imports style rules from other style sheets. */
-				'@import'?: unknown
-				/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
-				'@font-face'?: unknown
-			} & {
-				[K in Prelude]: K extends '@import'
-					? string | string[]
-				: K extends '@font-face'
-					? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
-				: K extends `@keyframes ${string}`
-					? {
-						[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-					}
-				: K extends `@property ${string}`
-					? CSSUtil.Native.AtRule.Property
-				: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-			}
+			...styles: (
+				& {
+					/** The **@import** CSS at-rule imports style rules from other style sheets. */
+					'@import'?: unknown
+					/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
+					'@font-face'?: unknown
+				}
+				& {
+					[K in Prelude]: K extends '@import'
+						? string | string[]
+					: K extends '@font-face'
+						? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
+					: K extends `@keyframes ${string}`
+						? {
+							[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+						}
+					: K extends `@property ${string}`
+						? CSSUtil.Native.AtRule.Property
+					: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+				}
+			)[]
 		): {
 			(): string
 		}

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -28,24 +28,27 @@ export default interface Stitches<
 	 */
 	globalCss: {
 		<Prelude extends string>(
-			style: {
-				/** The **@import** CSS at-rule imports style rules from other style sheets. */
-				'@import'?: unknown
-				/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
-				'@font-face'?: unknown
-			} & {
-				[K in Prelude]: K extends '@import'
-					? string
-				: K extends '@font-face'
-					? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
-				: K extends `@keyframes ${string}`
-					? {
-						[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-					}
-				: K extends `@property ${string}`
-					? CSSUtil.Native.AtRule.Property
-				: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-			}
+			...styles: (
+				& {
+					/** The **@import** CSS at-rule imports style rules from other style sheets. */
+					'@import'?: unknown
+					/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
+					'@font-face'?: unknown
+				}
+				& {
+					[K in Prelude]: K extends '@import'
+						? string | string[]
+					: K extends '@font-face'
+						? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
+					: K extends `@keyframes ${string}`
+						? {
+							[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+						}
+					: K extends `@property ${string}`
+						? CSSUtil.Native.AtRule.Property
+					: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+				}
+			)[]
 		): {
 			(): string
 		}


### PR DESCRIPTION
This PR changes the `globalCss` function to support multiple arguments of global styles. It also updates the types to support this behavior.

Resolves https://github.com/modulz/stitches/issues/758