### PR TITLE
754: Resolve TS issue on VariantProps

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2,7 +2,7 @@ import type Stitches from './stitches'
 
 import type * as Config from './config'
 import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
+import type * as S from './styled-component'
 
 export type CreateStitches = Config.CreateStitches
 export type CSSProperties = CSSUtil.CSSProperties
@@ -39,7 +39,12 @@ export type PropertyValue<K extends keyof CSSUtil.CSSProperties> = { readonly [C
 export type ScaleValue<K> = { readonly [CSSUtil.$$ScaleValue]: K }
 
 /** Returns a type that suggests variants from a component as possible prop values. */
-export type VariantProps<Component> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
+export type VariantProps<
+  C extends S.CssComponent<
+    C[S.$$StyledComponentType], C[S.$$StyledComponentProps], C[S.$$StyledComponentMedia]
+  >
+> = S.TransformProps<C[S.$$StyledComponentProps], C[S.$$StyledComponentMedia]>
+
 
 /** Map of CSS properties to token scales. */
 export declare const defaultThemeMap: DefaultThemeMap

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -2,7 +2,7 @@ import type Stitches from './stitches'
 
 import type * as Config from './config'
 import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
+import type * as S from './styled-component'
 
 export type CreateStitches = Config.CreateStitches
 export type CSSProperties = CSSUtil.CSSProperties
@@ -39,7 +39,12 @@ export type PropertyValue<K extends keyof CSSUtil.CSSProperties> = { readonly [C
 export type ScaleValue<K> = { readonly [CSSUtil.$$ScaleValue]: K }
 
 /** Returns a type that suggests variants from a component as possible prop values. */
-export type VariantProps<Component> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
+export type VariantProps<
+  C extends S.StyledComponent<
+    C[S.$$StyledComponentType], C[S.$$StyledComponentProps], C[S.$$StyledComponentMedia]
+  >
+> = S.TransformProps<C[S.$$StyledComponentProps], C[S.$$StyledComponentMedia]>
+
 
 /** Map of CSS properties to token scales. */
 export declare const defaultThemeMap: DefaultThemeMap


### PR DESCRIPTION
- Resolves issue #754.
- Needed to ensure that the `Component` generic extended the `CssComponent`/`StyledComponent` type.
- Shortened `Component` to `C`, and `type * as StyledComponent` to `type * as S`, due to the amount of repetition, to keep the code legible.