### PR TITLE
fix: Apply symbol type fix from core to react

### DIFF
--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -39,7 +39,7 @@ export type PropertyValue<K extends keyof CSSUtil.CSSProperties> = { readonly [C
 export type ScaleValue<K> = { readonly [CSSUtil.$$ScaleValue]: K }
 
 /** Returns a type that suggests variants from a component as possible prop values. */
-export type VariantProps<Component> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
+export type VariantProps<Component extends {[key: symbol | string]: any}> = StyledComponent.TransformProps<Component[StyledComponent.$$StyledComponentProps], Component[StyledComponent.$$StyledComponentMedia]>
 
 /** Map of CSS properties to token scales. */
 export declare const defaultThemeMap: DefaultThemeMap


### PR DESCRIPTION
This fix applies the same fix from https://github.com/modulz/stitches/pull/757 to the react package.