### PR TITLE
fix: jsdoc annotation for `compoundVariants`

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -146,7 +146,7 @@ export default interface Stitches<
 								[Pair in number | string]: CSS
 							}
 						}
-						/** The **variants** property lets you to set a subclass of styles based on a combination of active variants.
+						/** The **compoundVariants** property lets you to set a subclass of styles based on a combination of active variants.
 						 *
 						 * [Read Documentation](https://stitches.dev/docs/variants#compound-variants)
 						 */

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -148,7 +148,7 @@ export default interface Stitches<
 								[Pair in number | string]: CSS
 							}
 						}
-						/** The **variants** property lets you to set a subclass of styles based on a combination of active variants.
+						/** The **compoundVariants** property lets you to set a subclass of styles based on a combination of active variants.
 						 *
 						 * [Read Documentation](https://stitches.dev/docs/variants#compound-variants)
 						 */
@@ -218,7 +218,7 @@ export default interface Stitches<
 								[Pair in number | string]: CSS
 							}
 						}
-						/** The **variants** property lets you to set a subclass of styles based on a combination of active variants.
+						/** The **compoundVariants** property lets you to set a subclass of styles based on a combination of active variants.
 						 *
 						 * [Read Documentation](https://stitches.dev/docs/variants#compound-variants)
 						 */


### PR DESCRIPTION
This PR fixes JSDoc annotations for `compoundVariants` property.