### PR TITLE
Fix TS issue with globalCss

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -27,28 +27,31 @@ export default interface Stitches<
 	 * [Read Documentation](https://stitches.dev/docs/variants)
 	 */
 	globalCss: {
-		<Prelude extends string>(
-			...styles: (
-				& {
-					/** The **@import** CSS at-rule imports style rules from other style sheets. */
-					'@import'?: unknown
-					/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
-					'@font-face'?: unknown
-				}
-				& {
-					[K in Prelude]: K extends '@import'
-						? string | string[]
-					: K extends '@font-face'
-						? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
-					: K extends `@keyframes ${string}`
-						? {
-							[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-						}
-					: K extends `@property ${string}`
-						? CSSUtil.Native.AtRule.Property
-					: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-				}
-			)[]
+		<Styles extends { [K: string]: unknown }[]>(
+			...styles: {
+				[Index in keyof Styles]: (
+					& {
+						/** The **@import** CSS at-rule imports style rules from other style sheets. */
+						'@import'?: unknown
+
+						/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
+						'@font-face'?: unknown
+					}
+					& {
+						[K in keyof Styles[Index]]: K extends '@import'
+							? string | string[]
+						: K extends '@font-face'
+							? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
+						: K extends `@keyframes ${string}`
+							? {
+								[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+							}
+						: K extends `@property ${string}`
+							? CSSUtil.Native.AtRule.Property
+						: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+					}
+				)
+			}
 		): {
 			(): string
 		}

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -27,28 +27,31 @@ export default interface Stitches<
 	 * [Read Documentation](https://stitches.dev/docs/variants)
 	 */
 	globalCss: {
-		<Prelude extends string>(
-			...styles: (
-				& {
-					/** The **@import** CSS at-rule imports style rules from other style sheets. */
-					'@import'?: unknown
-					/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
-					'@font-face'?: unknown
-				}
-				& {
-					[K in Prelude]: K extends '@import'
-						? string | string[]
-					: K extends '@font-face'
-						? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
-					: K extends `@keyframes ${string}`
-						? {
-							[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-						}
-					: K extends `@property ${string}`
-						? CSSUtil.Native.AtRule.Property
-					: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
-				}
-			)[]
+		<Styles extends { [K: string]: unknown }[]>(
+			...styles: {
+				[Index in keyof Styles]: (
+					& {
+						/** The **@import** CSS at-rule imports style rules from other style sheets. */
+						'@import'?: unknown
+
+						/** The **@font-face** CSS at-rule specifies a custom font with which to display text. */
+						'@font-face'?: unknown
+					}
+					& {
+						[K in keyof Styles[Index]]: K extends '@import'
+							? string | string[]
+						: K extends '@font-face'
+							? CSSUtil.Native.AtRule.FontFace | CSSUtil.Native.AtRule.FontFace[]
+						: K extends `@keyframes ${string}`
+							? {
+								[KeyFrame in string]: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+							}
+						: K extends `@property ${string}`
+							? CSSUtil.Native.AtRule.Property
+						: CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
+					}
+				)
+			}
 		): {
 			(): string
 		}


### PR DESCRIPTION
This resolves a TypeScript issue where multiple styles passed into `globalCss` throw a typing error.

Resolves https://github.com/modulz/stitches/issues/794