### PR TITLE
Fix issue with default theme typing

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -109,16 +109,22 @@ export default interface Stitches<
 					: ThemeTokens<Argument0, Prefix>
 			)
 	}
-	theme: string & {
-		[Scale in keyof Theme]: {
-			[Token in keyof Theme[Scale]]: ThemeUtil.Token<
-				Extract<Token, string | number>,
-				string,
-				Extract<Scale, string | void>,
-				Extract<Prefix, string | void>
-			>
+	theme:
+		string 
+		& {
+			className: string
+			selector: string
 		}
-	}
+		& {
+			[Scale in keyof Theme]: {
+				[Token in keyof Theme[Scale]]: ThemeUtil.Token<
+					Extract<Token, string | number>,
+					string,
+					Extract<Scale, string | void>,
+					Extract<Prefix, string | void>
+				>
+			}
+		}
 	reset: {
 		(): void
 	}

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -109,16 +109,22 @@ export default interface Stitches<
 					: ThemeTokens<Argument0, Prefix>
 			)
 	}
-	theme: string & {
-		[Scale in keyof Theme]: {
-			[Token in keyof Theme[Scale]]: ThemeUtil.Token<
-				Extract<Token, string | number>,
-				string,
-				Extract<Scale, string | void>,
-				Extract<Prefix, string | void>
-			>
+	theme:
+		string 
+		& {
+			className: string
+			selector: string
 		}
-	}
+		& {
+			[Scale in keyof Theme]: {
+				[Token in keyof Theme[Scale]]: ThemeUtil.Token<
+					Extract<Token, string | number>,
+					string,
+					Extract<Scale, string | void>,
+					Extract<Prefix, string | void>
+				>
+			}
+		}
 	reset: {
 		(): void
 	}


### PR DESCRIPTION
This change fixes an issue with the typing for the default theme, exposing `className` and `selector`, which are otherwise available on any theme created with `createTheme`.

This resolves #781