### PR TITLE
Add distributive condition to `Assign` util

### DIFF
--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -166,3 +166,19 @@ void function Test() {
 		}} />
 	)
 }
+
+/* -------------------------------------------------------------------------------------------------
+ * Issue #821
+ * -----------------------------------------------------------------------------------------------*/
+
+type UnionProps = { type: 'single', collapsible: boolean; } | { type: 'multiple' };
+const UnionComponent: React.FC<UnionProps> = () => null
+const StyledUnionComponent = styled(UnionComponent, {})
+
+void function Test() {
+	<>
+		<StyledUnionComponent type="single" collapsible />
+		{/* @ts-expect-error */}
+		<StyledUnionComponent type="multiple" collapsible />
+	</>
+}

--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -2,7 +2,7 @@
 import * as Stitches from '../types/index'
 import { createStitches } from '../types/index'
 
-const { css, global, keyframes, styled, theme } = createStitches({
+const { css, globalCss, keyframes, styled, theme } = createStitches({
 	utils: {
 		mx: (value: Stitches.PropertyValue<'marginLeft'>) => ({
 			marginLeft: value,
@@ -54,7 +54,7 @@ keyframes({
 	},
 })
 
-global({
+globalCss({
 	body: {
 		backgroundColor: '$gray300',
 		'@bp1': {

--- a/packages/react/types/util.d.ts
+++ b/packages/react/types/util.d.ts
@@ -5,7 +5,7 @@
 export type Prefixed<K extends string, T> = `${K}${Extract<T, boolean | number | string>}`
 
 /** Returns an object from the given object assigned with the values of another given object. */
-export type Assign<T1 = {}, T2 = {}> = Omit<T1, keyof T2> & T2
+export type Assign<T1 = {}, T2 = {}> = T1 extends any ? Omit<T1, keyof T2> & T2 : never
 
 /** Returns a widened value from the given value. */
 export type Widen<T> =


### PR DESCRIPTION
Fixes #821 by adding support for components with union prop types.

https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types