### PR TITLE
Fix an issue with utils named like selectors

### DIFF
--- a/packages/core/src/convert/toCssRules.js
+++ b/packages/core/src/convert/toCssRules.js
@@ -52,14 +52,14 @@ export const toCssRules = (
 				const datas = isAtRuleLike && Array.isArray(style[name]) ? style[name] : [style[name]]
 
 				for (data of datas) {
-					/** Whether the current data represents a nesting rule. */
-					const isRuleLike = typeof data === 'object' && data && data.toString === toStringOfObject
-
 					const camelName = toCamelCase(name)
+					
+					/** Whether the current data represents a nesting rule, which is a plain object whose key is not already a util. */
+					const isRuleLike = typeof data === 'object' && data && data.toString === toStringOfObject && (!config.utils[camelName] || !selectors.length)
 
 					// if the left-hand "name" matches a configured utility
 					// conditionally transform the current data using the configured utility
-					if (camelName in config.utils) {
+					if (camelName in config.utils && !isRuleLike) {
 						const util = config.utils[camelName]
 
 						if (util !== lastUtil) {

--- a/packages/core/tests/issue-788.js
+++ b/packages/core/tests/issue-788.js
@@ -1,0 +1,56 @@
+import { createStitches } from '../src/index.js'
+
+describe('Issue #788', () => {
+	test('Test that a util with the name of a selector works in globalCss', () => {
+		const { globalCss, getCssText } = createStitches({
+			utils: {
+				p: (value) => ({
+					paddingTop: value,
+					paddingBottom: value,
+					paddingLeft: value,
+					paddingRight: value,
+				}),
+			},
+		})
+
+		globalCss({
+			p: {
+				color: 'red',
+			}
+		})()
+
+		expect(getCssText()).toBe(
+			`--sxs{--sxs:1 gllaiB}` +
+			`@media{p{` +
+				`color:red` +
+			`}}`
+		)
+	})
+
+	test('Test that a util with the name of a selector works in a component', () => {
+		const { css, getCssText } = createStitches({
+			utils: {
+				p: (value) => ({
+					paddingTop: value,
+					paddingBottom: value,
+					paddingLeft: value,
+					paddingRight: value,
+				}),
+			},
+		})
+
+		css({
+			p: 10
+		})()
+
+		expect(getCssText()).toBe(
+			`--sxs{--sxs:2 c-csWWxC}` +
+			`@media{.c-csWWxC{` +
+				`padding-top:10px;` +
+				`padding-bottom:10px;` +
+				`padding-left:10px;` +
+				`padding-right:10px` +
+			`}}`
+		)
+	})
+})


### PR DESCRIPTION
This fixes an issue with using utils that share the same name as a selector.

Resolves https://github.com/modulz/stitches/issues/788