### PR TITLE
improve injection order

### DIFF
--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -2,6 +2,16 @@
 /** @typedef {import('./sheet').RuleGroupNames} RuleGroupNames */
 /** @typedef {import('./sheet').SheetGroup} SheetGroup */
 
+/**
+ * Rules in the sheet appear in this order:
+ * 1. theme rules (themed)
+ * 2. global rules (global)
+ * 3. component rules (styled)
+ * 4. non-responsive variants rules (onevar)
+ * 5. responsive variants rules (resonevar)
+ * 6. compound variants rules (allvar)
+ * 7. inline rules (inline)
+ */
 /** @type {RuleGroupNames} */
 export const names = ['themed', 'global', 'styled', 'onevar', 'resonevar', 'allvar', 'inline']
 
@@ -159,6 +169,12 @@ const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 }
 /** Pending rules for injection */
 const $pr = Symbol()
+
+/** 
+ * When a stitches component is extending some other random react component,
+ * it’s gonna create a react component (Injector) using this function and then render it after the children, 
+ * this way, we would force the styles of the wrapper to be injected after the wrapped component
+ */
 export const createRulesInjectionDeferrer = (globalSheet) => {
 	// the injection deferrer
 	function injector() {

--- a/packages/core/tests/basic.js
+++ b/packages/core/tests/basic.js
@@ -119,7 +119,7 @@ describe('Basic', () => {
 			`--sxs{--sxs:2 c-dataoT}@media{` +
 				`.c-dataoT{color:DodgerBlue}` +
 			`}` +
-			`--sxs{--sxs:5 c-dataoT-icaIZdx-css}@media{` +
+			`--sxs{--sxs:6 c-dataoT-icaIZdx-css}@media{` +
 				`.c-dataoT-icaIZdx-css{color:Crimson}` +
 			`}`
 		)

--- a/packages/core/tests/component-css-prop.js
+++ b/packages/core/tests/component-css-prop.js
@@ -22,7 +22,7 @@ describe('Component with CSS prop', () => {
 			`--sxs{--sxs:2 c-hhyRYU}@media{` +
 				`.c-hhyRYU{order:1}` +
 			`}` +
-			`--sxs{--sxs:5 c-hhyRYU-ilhKMMn-css}@media{` +
+			`--sxs{--sxs:6 c-hhyRYU-ilhKMMn-css}@media{` +
 				`.c-hhyRYU-ilhKMMn-css{order:2}` +
 			`}`
 		)

--- a/packages/core/tests/component-empty-variants.js
+++ b/packages/core/tests/component-empty-variants.js
@@ -52,7 +52,7 @@ describe('Empty Variants', () => {
 		})
 
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:4 c-PJLV-lhHHWD-cv}@media{` +
+			`--sxs{--sxs:5 c-PJLV-lhHHWD-cv}@media{` +
 				`.c-PJLV-lhHHWD-cv{font-size:24px;color:black}` +
 			`}`
 		)

--- a/packages/core/tests/component-variants.js
+++ b/packages/core/tests/component-variants.js
@@ -113,7 +113,7 @@ describe('Variants', () => {
 		expect(getCssText()).toBe(
 			`--sxs{--sxs:3 c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small}@media{${
 				expressionColorBlueCssText + expressionSizeSmallCssText
-			}}--sxs{--sxs:4 c-PJLV-cChFtv-cv}@media{${
+			}}--sxs{--sxs:5 c-PJLV-cChFtv-cv}@media{${
 				expressionCompoundCssText
 			}}`
 		)
@@ -219,7 +219,7 @@ describe('Variants with defaults', () => {
 				`.c-PJLV-kaCQqN-color-blue{background-color:dodgerblue;color:white}` +
 				// implicit size:small
 				`.c-PJLV-Gaggi-size-small{font-size:16px}` +
-			`}--sxs{--sxs:4 c-PJLV-cChFtv-cv}@media{` +
+			`}--sxs{--sxs:5 c-PJLV-cChFtv-cv}@media{` +
 				// compound color:blue + size:small
 				`.c-PJLV-cChFtv-cv{transform:scale(1.2)}` +
 			`}`,
@@ -311,7 +311,7 @@ describe('Conditional variants', () => {
 
 		expect(component({ size: { '@bp1': 'small' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small`)
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 			`}`
 		)
@@ -328,7 +328,7 @@ describe('Conditional variants', () => {
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe([componentClassName, componentSmallBp1ClassName, componentLargeBp2ClassName].join(' '))
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				componentSmallBp1CssText +
 				componentLargeBp2CssText +
 			`}`
@@ -341,7 +341,7 @@ describe('Conditional variants', () => {
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
 			`}`
@@ -349,7 +349,7 @@ describe('Conditional variants', () => {
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
 			`}`
@@ -357,7 +357,7 @@ describe('Conditional variants', () => {
 
 		expect(component({ size: { '@bp1': 'small', '@bp2': 'large' } }).className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
 		expect(getCssText()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
 			`}`
@@ -390,7 +390,7 @@ describe('Conditional variants', () => {
 			).toBe('c-PJLV c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large')
 
 			expect(getCssText()).toBe(
-				`--sxs{--sxs:3 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
+				`--sxs{--sxs:4 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
 					`@media (max-width:767.9375px){.c-PJLV-gjWYHE-size-small{font-size:16px}}` +
 					`@media (min-width:768px){.c-PJLV-fzmUzy-size-large{font-size:24px}}` +
 				`}`
@@ -422,7 +422,7 @@ describe('Conditional variants', () => {
 			).toBe('c-PJLV c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large')
 
 			expect(getCssText()).toBe(
-				`--sxs{--sxs:3 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
+				`--sxs{--sxs:4 c-PJLV-gjWYHE-size-small c-PJLV-fzmUzy-size-large}@media{` +
 					`@media (max-width:767.9375px){.c-PJLV-gjWYHE-size-small{font-size:16px}}` +
 					`@media (min-width:768px){.c-PJLV-fzmUzy-size-large{font-size:24px}}` +
 				`}`
@@ -499,7 +499,7 @@ describe('Variant pairing types', () => {
 			`--sxs{--sxs:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +
-			`--sxs{--sxs:3 c-foEXqW-brOaTK-testBoolean-true}@media{` +
+			`--sxs{--sxs:4 c-foEXqW-brOaTK-testBoolean-true}@media{` +
 				`@media (min-width: 640px){` +
 					`.c-foEXqW-brOaTK-testBoolean-true{--test-boolean:true}` +
 				`}` +
@@ -517,7 +517,7 @@ describe('Variant pairing types', () => {
 			`--sxs{--sxs:2 c-foEXqW}@media{` +
 				`.c-foEXqW{--component:true}` +
 			`}` +
-			`--sxs{--sxs:3 c-foEXqW-brOaTK-testBoolean-true}@media{` +
+			`--sxs{--sxs:4 c-foEXqW-brOaTK-testBoolean-true}@media{` +
 				`@media (min-width: 640px){` +
 					`.c-foEXqW-brOaTK-testBoolean-true{--test-boolean:true}` +
 				`}` +

--- a/packages/core/tests/issue-450.js
+++ b/packages/core/tests/issue-450.js
@@ -77,7 +77,7 @@ describe('Issue #450', () => {
 			const { component1, getCssText } = getFreshComponents()
 			const render = component1({ color: { '@media (min-width: 640px)': 'blue' } })
 			expect(render.className).toBe(`c-PJLV c-PJLV-gmqXFB-color-red c-PJLV-bBevdw-color-blue`)
-			expect(getCssText()).toBe(`--sxs{--sxs:3 c-PJLV-gmqXFB-color-red c-PJLV-bBevdw-color-blue}@media{.c-PJLV-gmqXFB-color-red{color:red}@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}}`)
+			expect(getCssText()).toBe(`--sxs{--sxs:3 c-PJLV-gmqXFB-color-red}@media{.c-PJLV-gmqXFB-color-red{color:red}}--sxs{--sxs:4 c-PJLV-bBevdw-color-blue}@media{@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}}`)
 		})
 
 		test('Render component2() as orange, inherited from defaultVariants', () => {
@@ -93,10 +93,7 @@ describe('Issue #450', () => {
 			const render = component2({ color: { '@media (min-width: 640px)': 'blue' } })
 			expect(render.className).toBe(`c-PJLV c-PJLV-bBevdw-color-blue c-PJLV-vMTTG-color-orange`)
 			expect(getCssText()).toBe(
-				`--sxs{--sxs:3 c-PJLV-bBevdw-color-blue c-PJLV-vMTTG-color-orange}@media{` +
-					`@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}` +
-					`.c-PJLV-vMTTG-color-orange{color:orange}` +
-				`}`
+				`--sxs{--sxs:3 c-PJLV-vMTTG-color-orange}` + `@media{.c-PJLV-vMTTG-color-orange{color:orange}}` + `--sxs{--sxs:4 c-PJLV-bBevdw-color-blue}@media{` + `@media (min-width: 640px){.c-PJLV-bBevdw-color-blue{color:blue}}` + `}`,
 			)
 		})
 	})
@@ -190,14 +187,14 @@ describe('Issue #450', () => {
 			expect(getCssText()).toBe(
 				`--sxs{--sxs:2 c-jyxqjt}@media{` +
 					`.c-jyxqjt{--component:1}` +
-				`}` +
-				`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
+					`}` +
+					`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
 					`.c-jyxqjt-cOChOn-appearance-secondary{--appearance:secondary}` +
 					`.c-jyxqjt-ilDyRi-color-lightBlue{--color:lightBlue}` +
-				`}` +
-				`--sxs{--sxs:4 c-jyxqjt-gYqlvA-cv}@media{` +
+					`}` +
+					`--sxs{--sxs:5 c-jyxqjt-gYqlvA-cv}@media{` +
 					`.c-jyxqjt-gYqlvA-cv{--compound:appearance secondary / color lightBlue}` +
-				`}`
+					`}`,
 			)
 		})
 
@@ -209,14 +206,14 @@ describe('Issue #450', () => {
 				`--sxs{--sxs:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +
 					`.c-dkRcuu{--component:2}` +
-				`}` +
-				`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
+					`}` +
+					`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
 					`.c-jyxqjt-cOChOn-appearance-secondary{--appearance:secondary}` +
 					`.c-jyxqjt-ilDyRi-color-lightBlue{--color:lightBlue}` +
-				`}` +
-				`--sxs{--sxs:4 c-jyxqjt-gYqlvA-cv}@media{` +
+					`}` +
+					`--sxs{--sxs:5 c-jyxqjt-gYqlvA-cv}@media{` +
 					`.c-jyxqjt-gYqlvA-cv{--compound:appearance secondary / color lightBlue}` +
-				`}`
+					`}`,
 			)
 		})
 
@@ -228,14 +225,14 @@ describe('Issue #450', () => {
 				`--sxs{--sxs:2 c-jyxqjt c-dkRcuu}@media{` +
 					`.c-jyxqjt{--component:1}` +
 					`.c-dkRcuu{--component:2}` +
-				`}` +
-				`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
+					`}` +
+					`--sxs{--sxs:3 c-jyxqjt-cOChOn-appearance-secondary c-jyxqjt-ilDyRi-color-lightBlue}@media{` +
 					`.c-jyxqjt-cOChOn-appearance-secondary{--appearance:secondary}` +
 					`.c-jyxqjt-ilDyRi-color-lightBlue{--color:lightBlue}` +
-				`}` +
-				`--sxs{--sxs:4 c-jyxqjt-gYqlvA-cv}@media{` +
+					`}` +
+					`--sxs{--sxs:5 c-jyxqjt-gYqlvA-cv}@media{` +
 					`.c-jyxqjt-gYqlvA-cv{--compound:appearance secondary / color lightBlue}` +
-				`}`
+					`}`,
 			)
 		})
 	})

--- a/packages/core/tests/issue-492.js
+++ b/packages/core/tests/issue-492.js
@@ -57,13 +57,12 @@ describe('Issue #492', () => {
 			`${componentClassName} ${variantSweetCarolineClassName} ${variantResponsiveSweetDreamsClassName}`
 		)
 
-		expect(
-			getCssText()
-		).toBe(
-			`--sxs{--sxs:3 ${variantSweetCarolineClassName} ${variantResponsiveSweetDreamsClassName}}@media{` +
-				`.${variantSweetCarolineClassName}{--sweet-caroline:true}` +
+		expect(getCssText()).toBe(
+			`--sxs{--sxs:3 ${variantSweetCarolineClassName}}` +
+				`@media{.${variantSweetCarolineClassName}{--sweet-caroline:true}}` +
+				`--sxs{--sxs:4 ${variantResponsiveSweetDreamsClassName}}@media{` +
 				`@media (min-width: 640px){.${variantResponsiveSweetDreamsClassName}{--sweet-dreams:true}}` +
-			`}`
+				`}`,
 		)
 
 		/** Rendering of the component as-is. */
@@ -74,23 +73,17 @@ describe('Issue #492', () => {
 			},
 		})
 
-		expect(
-			rendering3.className
-		).toBe(
-			`${componentClassName} ${variantSweetDreamsClassName} ${variantResponsiveSweetCarolineClassName}`
-		)
+		expect(rendering3.className).toBe(`${componentClassName} ${variantSweetDreamsClassName} ${variantResponsiveSweetCarolineClassName}`)
 
-		expect(
-			getCssText()
-		).toBe(
-			`--sxs{--sxs:3 ${variantSweetCarolineClassName} ${variantResponsiveSweetDreamsClassName} ${variantSweetDreamsClassName} ${variantResponsiveSweetCarolineClassName}}@media{` +
-				// last rendering
-				`.${variantSweetCarolineClassName}{--sweet-caroline:true}` +
+		expect(getCssText()).toBe(
+				// initial variants
+				`--sxs{--sxs:3 ${variantSweetCarolineClassName} ${variantSweetDreamsClassName}}` +
+				`@media{.${variantSweetCarolineClassName}{--sweet-caroline:true}.${variantSweetDreamsClassName}{--sweet-dreams:true}}` +
+				// responsive variants
+				`--sxs{--sxs:4 ${variantResponsiveSweetDreamsClassName} ${variantResponsiveSweetCarolineClassName}}@media{` +
 				`@media (min-width: 640px){.${variantResponsiveSweetDreamsClassName}{--sweet-dreams:true}}` +
-				// this rendering
-				`.${variantSweetDreamsClassName}{--sweet-dreams:true}` +
 				`@media (min-width: 640px){.${variantResponsiveSweetCarolineClassName}{--sweet-caroline:true}}` +
-			`}`
+				`}`,
 		)
 	})
 
@@ -131,14 +124,6 @@ describe('Issue #492', () => {
 
 		expect(
 			getCssText()
-		).toBe(
-			`--sxs{--sxs:2 ${componentClassName}}@media{` +
-				`.${componentClassName}{--rock:true}` +
-			`}` +
-			`--sxs{--sxs:3 ${variantInitialHeavyIronButterfly} ${variantMinWidth640LedZeppelin}}@media{` +
-				`.${variantInitialHeavyIronButterfly}{--weight-iron-butterfly:true}` +
-				`@media (min-width: 640px){.${variantMinWidth640LedZeppelin}{--weight-led-zeppelin:true}}` +
-			`}`
-		)
+		).toBe('--sxs{--sxs:2 c-evVBJo}@media{.c-evVBJo{--rock:true}}--sxs{--sxs:3 c-evVBJo-kiVNrc-heavy-iron-butterfly}@media{.c-evVBJo-kiVNrc-heavy-iron-butterfly{--weight-iron-butterfly:true}}--sxs{--sxs:4 c-evVBJo-lgYcvN-heavy-led-zeppelin}@media{@media (min-width: 640px){.c-evVBJo-lgYcvN-heavy-led-zeppelin{--weight-led-zeppelin:true}}}')
 	})
 })

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -22,11 +22,15 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			const styledComponent = React.forwardRef((props, ref) => {
 				const Type = props && props.as || DefaultType
 
-				const forwardProps = cssComponent(props).props
+				const { props: forwardProps, differedInjector } = cssComponent(props)
 
 				delete forwardProps.as
 
 				forwardProps.ref = ref
+
+				if (differedInjector) {
+					return React.createElement(React.Fragment, null, React.createElement(Type, forwardProps), React.createElement(differedInjector, null))
+				}
 
 				return React.createElement(Type, forwardProps)
 			})

--- a/packages/react/tests/component-css-prop-react.js
+++ b/packages/react/tests/component-css-prop-react.js
@@ -86,7 +86,7 @@ describe('React Component with CSS prop', () => {
 		})
 
 		expect(toString()).toBe(
-			`--sxs{--sxs:2 c-bMUtqP}@media{.c-bMUtqP{line-height:1;margin:0;font-weight:400;font-variant-numeric:tabular-nums;display:block}}--sxs{--sxs:5 c-bMUtqP-ieTXEfC-css}@media{.c-bMUtqP-ieTXEfC-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px;text-align:center;margin-bottom:var(--space-3)}@media (min-width: 900px){.c-bMUtqP-ieTXEfC-css{line-height:55px;color:red}}}`,
+			`--sxs{--sxs:2 c-bMUtqP}@media{.c-bMUtqP{line-height:1;margin:0;font-weight:400;font-variant-numeric:tabular-nums;display:block}}--sxs{--sxs:6 c-bMUtqP-ieTXEfC-css}@media{.c-bMUtqP-ieTXEfC-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px;text-align:center;margin-bottom:var(--space-3)}@media (min-width: 900px){.c-bMUtqP-ieTXEfC-css{line-height:55px;color:red}}}`,
 		)
 
 		// ...
@@ -105,7 +105,7 @@ describe('React Component with CSS prop', () => {
 		})
 
 		expect(toString()).toBe(
-			`--sxs{--sxs:2 c-bMUtqP c-dnnagC}@media{.c-bMUtqP{line-height:1;margin:0;font-weight:400;font-variant-numeric:tabular-nums;display:block}.c-dnnagC .c-bMUtqP{color:inherit}}--sxs{--sxs:5 c-bMUtqP-ieTXEfC-css}@media{.c-bMUtqP-ieTXEfC-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px;text-align:center;margin-bottom:var(--space-3)}@media (min-width: 900px){.c-bMUtqP-ieTXEfC-css{line-height:55px;color:red}}}`,
+			`--sxs{--sxs:2 c-bMUtqP c-dnnagC}@media{.c-bMUtqP{line-height:1;margin:0;font-weight:400;font-variant-numeric:tabular-nums;display:block}.c-dnnagC .c-bMUtqP{color:inherit}}--sxs{--sxs:6 c-bMUtqP-ieTXEfC-css}@media{.c-bMUtqP-ieTXEfC-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px;text-align:center;margin-bottom:var(--space-3)}@media (min-width: 900px){.c-bMUtqP-ieTXEfC-css{line-height:55px;color:red}}}`,
 		)
 	})
 })

--- a/packages/react/tests/component-css-prop.js
+++ b/packages/react/tests/component-css-prop.js
@@ -12,7 +12,7 @@ describe('React Component with CSS prop', () => {
 			},
 		})
 
-		expect(toString()).toBe(`--sxs{--sxs:2 c-hhyRYU}@media{.c-hhyRYU{order:1}}--sxs{--sxs:5 c-hhyRYU-ilhKMMn-css}@media{.c-hhyRYU-ilhKMMn-css{order:2}}`)
+		expect(toString()).toBe(`--sxs{--sxs:2 c-hhyRYU}@media{.c-hhyRYU{order:1}}--sxs{--sxs:6 c-hhyRYU-ilhKMMn-css}@media{.c-hhyRYU-ilhKMMn-css{order:2}}`)
 	})
 
 	test('React example from Radix', () => {
@@ -41,7 +41,7 @@ describe('React Component with CSS prop', () => {
 		})
 
 		expect(toString()).toBe(
-			`--sxs{--sxs:2 c-bHwuwj}@media{.c-bHwuwj{color:inherit}}--sxs{--sxs:5 c-bHwuwj-ibwrayD-css}@media{.c-bHwuwj-ibwrayD-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px}@media (min-width: 900px){.c-bHwuwj-ibwrayD-css{line-height:55px;color:red}}}`,
+			`--sxs{--sxs:2 c-bHwuwj}@media{.c-bHwuwj{color:inherit}}--sxs{--sxs:6 c-bHwuwj-ibwrayD-css}@media{.c-bHwuwj-ibwrayD-css{font-weight:500;font-variant-numeric:proportional-nums;line-height:35px}@media (min-width: 900px){.c-bHwuwj-ibwrayD-css{line-height:55px;color:red}}}`,
 		)
 	})
 })

--- a/packages/react/tests/component-variants.js
+++ b/packages/react/tests/component-variants.js
@@ -95,7 +95,7 @@ describe('Variants', () => {
 			`--sxs{--sxs:3 c-PJLV-kaCQqN-color-blue c-PJLV-Gaggi-size-small}@media{` +
 				expressionColorBlueCssText +
 				expressionSizeSmallCssText +
-			`}--sxs{--sxs:4 c-PJLV-cChFtv-cv}@media{` +
+			`}--sxs{--sxs:5 c-PJLV-cChFtv-cv}@media{` +
 				expressionCompoundCssText +
 			`}`
 		)
@@ -201,7 +201,7 @@ describe('Variants with defaults', () => {
 				`.c-PJLV-kaCQqN-color-blue{background-color:dodgerblue;color:white}` +
 				// implicit size:small
 				`.c-PJLV-Gaggi-size-small{font-size:16px}` +
-			`}--sxs{--sxs:4 c-PJLV-cChFtv-cv}@media{` +
+			`}--sxs{--sxs:5 c-PJLV-cChFtv-cv}@media{` +
 				// compound color:blue + size:small
 				`.c-PJLV-cChFtv-cv{transform:scale(1.2)}` +
 			`}`
@@ -296,7 +296,7 @@ describe('Conditional variants', () => {
 
 		expect(component.render({ size: { '@bp1': 'small' } }).props.className).toBe([componentClassName, componentSmallBp1ClassName].join(' '))
 		expect(toString()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small}@media{` +
 				componentSmallBp1CssText +
 			`}`
 		)
@@ -313,7 +313,7 @@ describe('Conditional variants', () => {
 
 		expect(component.render({ size: { '@bp1': 'small', '@bp2': 'large' } }).props.className).toBe([componentClassName, componentSmallBp1ClassName, componentLargeBp2ClassName].join(' '))
 		expect(toString()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 			componentSmallBp1CssText +
 			componentLargeBp2CssText +
 			`}`
@@ -331,7 +331,7 @@ describe('Conditional variants', () => {
 
 		expect(component.render({ size: { '@bp1': 'small', '@bp2': 'large' } }).props.className).toBe([componentClassName, componentSmallBp1ClassName, componentLargeBp2ClassName].join(' '))
 		expect(toString()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				componentSmallBp1CssText +
 				componentLargeBp2CssText +
 			`}`
@@ -339,7 +339,7 @@ describe('Conditional variants', () => {
 
 		expect(component.render({ size: { '@bp1': 'small', '@bp2': 'large' } }).props.className).toBe([componentClassName, componentSmallBp1ClassName, componentLargeBp2ClassName].join(' '))
 		expect(toString()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
 			`}`
@@ -347,7 +347,7 @@ describe('Conditional variants', () => {
 
 		expect(component.render({ size: { '@bp1': 'small', '@bp2': 'large' } }).props.className).toBe(`c-PJLV c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large`)
 		expect(toString()).toBe(
-			`--sxs{--sxs:3 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
+			`--sxs{--sxs:4 c-PJLV-iVKIeV-size-small c-PJLV-bUkcYv-size-large}@media{` +
 				`@media (max-width: 767px){.c-PJLV-iVKIeV-size-small{font-size:16px}}` +
 				`@media (min-width: 768px){.c-PJLV-bUkcYv-size-large{font-size:24px}}` +
 			`}`

--- a/packages/react/tests/issue-416.js
+++ b/packages/react/tests/issue-416.js
@@ -53,9 +53,10 @@ describe('Issue #416: Composition versus Descendancy', () => {
 		}
 
 		let wrapper
-
-		renderer.act(() => {
-			wrapper = renderer.create(React.createElement(App))
+		test('it can render without errors', () => {
+			renderer.act(() => {
+				wrapper = renderer.create(React.createElement(App))
+			})
 		})
 
 		const [boxA, boxB, genY, boxZ] = wrapper.toJSON().children

--- a/packages/react/tests/issue-671.js
+++ b/packages/react/tests/issue-671.js
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import * as renderer from 'react-test-renderer'
+import { createStitches } from '../src/index.js'
+
+describe('Issue #671', () => {
+	{
+		const { styled, getCssText } = createStitches()
+
+		const StyledBase = styled('div', { color: 'red' })
+		const Base = (props) => React.createElement(StyledBase, { ...props })
+		const Bar = styled(Base, { color: 'blue' })
+
+		const App = () => {
+			return React.createElement(
+				'div',
+				null,
+				// children
+				React.createElement(Bar, {}),
+			)
+		}
+
+		renderer.act(() => {
+			renderer.create(React.createElement(App))
+		})
+
+		test('a stitches component extending a react component will inject the styles in the correct order', () => {
+			expect(getCssText()).toBe(`--sxs{--sxs:2 c-kydkiA c-gmqXFB}@media{.c-gmqXFB{color:red}.c-kydkiA{color:blue}}`)
+		})
+	}
+})

--- a/packages/react/tests/issue-737.js
+++ b/packages/react/tests/issue-737.js
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import * as renderer from 'react-test-renderer'
+import { createStitches } from '../src/index.js'
+
+describe('Issue #737', () => {
+	{
+		const { styled, getCssText } = createStitches({
+			media: {
+				bp1: '(min-width: 768px)',
+			},
+		})
+
+		const TestComponent = styled('div', {
+			variants: {
+				variant: {
+					red: {
+						color: 'red',
+					},
+				},
+			},
+		})
+
+		// now test that the initial variant in rendered fist
+		test('initial variants are rendered before responsive variants', () => {
+			// render responsive variants
+			renderer.act(() => {
+				renderer.create(
+					React.createElement(React.Fragment, null, [
+						// render responsive variant first without initial
+						React.createElement(TestComponent, { key: 0, variant: { '@bp1': 'red' } }),
+						// render initial variant
+						React.createElement(TestComponent, { key: 1, variant: {'@initial': 'red'} }),
+					]),
+				)
+			})
+			expect(getCssText()).toBe(`--sxs{--sxs:3 c-PJLV-gmqXFB-variant-red}@media{.c-PJLV-gmqXFB-variant-red{color:red}}--sxs{--sxs:4 c-PJLV-kmHUKy-variant-red}@media{@media (min-width: 768px){.c-PJLV-kmHUKy-variant-red{color:red}}}`)
+
+		})
+	}
+})


### PR DESCRIPTION
Fixes #737 by giving responsive variants and non-responsive variants different injection buckets instead of sharing the same one
Fixes #671 by making sure that a stitches component that wraps some another react component is going to defer the injection until after the inner component is rendered

Keeping it as a draft as I would like to merge this myself after the review as I would like to get #869 in first and then get this in as there is an area in this PR that would need an update after #869 is merged