### PR TITLE
878: Fixed issue with ThemeTokens typing

### DIFF
--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -204,7 +204,7 @@ type ThemeTokens<Values, Prefix> = {
 	[Scale in keyof Values]: {
 		[Token in keyof Values[Scale]]: ThemeUtil.Token<
 			Extract<Token, number | string>,
-			Values[Scale][Token] extends string | number ? Values[Scale][Token] : string,
+			Values[Scale][Token] & (string | number),
 			Extract<Scale, string | void>,
 			Extract<Prefix, string | void>
 		>

--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -204,7 +204,7 @@ type ThemeTokens<Values, Prefix> = {
 	[Scale in keyof Values]: {
 		[Token in keyof Values[Scale]]: ThemeUtil.Token<
 			Extract<Token, number | string>,
-			Values[Scale][Token],
+			Values[Scale][Token] extends string | number ? Values[Scale][Token] : string,
 			Extract<Scale, string | void>,
 			Extract<Prefix, string | void>
 		>

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -276,7 +276,7 @@ type ThemeTokens<Values, Prefix> = {
 	[Scale in keyof Values]: {
 		[Token in keyof Values[Scale]]: ThemeUtil.Token<
 			Extract<Token, number | string>,
-			Values[Scale][Token],
+			Values[Scale][Token] extends string | number ? Values[Scale][Token] : string,
 			Extract<Scale, string | void>,
 			Extract<Prefix, string | void>
 		>

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -276,7 +276,7 @@ type ThemeTokens<Values, Prefix> = {
 	[Scale in keyof Values]: {
 		[Token in keyof Values[Scale]]: ThemeUtil.Token<
 			Extract<Token, number | string>,
-			Values[Scale][Token] extends string | number ? Values[Scale][Token] : string,
+			Values[Scale][Token] & (string | number),
 			Extract<Scale, string | void>,
 			Extract<Prefix, string | void>
 		>


### PR DESCRIPTION
Simple fix to address the typing issue in #878; the offending type could be of types beyond `string | number`, so I added a type guard.

CC: @dlehmhus