### PR TITLE
improves compatibility with inconsistent CSSOM behavior of older browsers

### DIFF
--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -21,8 +21,7 @@ const isSheetAccessible = (/** @type {CSSStyleSheet} */ sheet) => {
 	}
 
 	try {
-		sheet.cssRules
-		return true
+		return !!sheet.cssRules
 	} catch (e) {
 		return false
 	}


### PR DESCRIPTION
Migrating from Emotion to Stitches, I ran into issues with an older iOS environment.

The cause is as described at https://github.com/modulz/stitches/issues/756

However, some old browsers assign null instead of throwing a `SecurityError` on the accessing `cssRules`.

![Screenshot 2022-01-20 PM 7 04 39](https://user-images.githubusercontent.com/9696352/150375897-0b043c23-70be-47f1-abdf-bf8b56930b06.png)
