### PR TITLE
fix: Specify missing exception identifier in `addApplyToGroup`

### DIFF
--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -178,7 +178,7 @@ const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 			groupingRule.insertRule(cssText, index)
 
 			++index
-		} catch {
+		} catch (__) {
 			// do nothing and continue
 		}
 	}


### PR DESCRIPTION
At my workplace, some of the users reported that the whole app gets unresponsive, only when they're using MS Edge browser.

Turns out, it was similar situation with what [this StackOverflow question](https://stackoverflow.com/questions/56479576/i-got-the-expected-script1005-with-javascript-on-edge-with-chrome-its-wor) describes. That is: some versions of MS Edge does not allow `catch` clause if there's no exception identifier (`(e)` part), and just throws `SCRIPT1005` error.

I'm not sure what exact version range of MS Edge has this issue. Nevertheless, I think this change might not hurt anyone and hopefully save someone's few hours.