### PR TITLE
Fix "length is declared here" issue with TS 4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "17.0.2",
     "react-test-renderer": "17.0.2",
     "terser": "5.9.0",
-    "typescript": "4.4.3"
+    "typescript": "4.6.2"
   },
   "browserslist": [
     "last 1 chrome versions",

--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -110,7 +110,7 @@ export default interface Stitches<
 			)
 	}
 	theme:
-		string 
+		string
 		& {
 			className: string
 			selector: string
@@ -143,7 +143,9 @@ export default interface Stitches<
 			...composers: {
 				[K in keyof Composers]: (
 					// Strings and Functions can be skipped over
-					Composers[K] extends string | Util.Function
+					string extends Composers[K]
+						? Composers[K]
+					: Composers[K] extends string | Util.Function
 						? Composers[K]
 					: RemoveIndex<CSS> & {
 						/** The **variants** property lets you set a subclass of styles based on a key-value pair.

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -110,7 +110,7 @@ export default interface Stitches<
 			)
 	}
 	theme:
-		string 
+		string
 		& {
 			className: string
 			selector: string
@@ -145,7 +145,9 @@ export default interface Stitches<
 			...composers: {
 				[K in keyof Composers]: (
 					// Strings, React Components, and Functions can be skipped over
-					Composers[K] extends string | React.ExoticComponent<any> | React.JSXElementConstructor<any> | Util.Function
+					string extends Composers[K]
+						? Composers[K]
+					: Composers[K] extends string | React.ExoticComponent<any> | React.JSXElementConstructor<any> | Util.Function
 						? Composers[K]
 					: RemoveIndex<CSS> & {
 						/** The **variants** property lets you set a subclass of styles based on a key-value pair.
@@ -208,14 +210,16 @@ export default interface Stitches<
 				| React.ComponentType<any>
 				| Util.Function
 				| { [name: string]: unknown }
-			)[], 
+			)[],
 			CSS = CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
 		>(
 			type: Type,
 			...composers: {
 				[K in keyof Composers]: (
 					// Strings, React Components, and Functions can be skipped over
-					Composers[K] extends string | React.ComponentType<any> | Util.Function
+					string extends Composers[K]
+						? Composers[K]
+					: Composers[K] extends string | React.ComponentType<any> | Util.Function
 						? Composers[K]
 					: RemoveIndex<CSS> & {
 						/** The **variants** property lets you set a subclass of styles based on a key-value pair.

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "prettier": "^1.16.4",
     "react": "17.0.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.6.2"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #947.

TypeScript 4.6 changed... something... that necessitated checking `string extends Composers[K]` in addition to `Composers[K] extends string` to filter out string-assignable types.

This error actually surfaces in `test/build-types/built-types-test.tsx` if you switch to TS 4.6, but it looks like those types are generated manually based on published Stitches versions, so I didn't touch them in this PR.